### PR TITLE
fix: directory state check

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ref | description
 copy_complete | Triggers when CopyComplete.txt is found in a directory
 new_directory | Triggers when a new directory is found
 
-> [!TIP]
+> [!NOTE]
 > Note that the triggers that are connected to analysis directories will not be emitted unless `CopyComplete.txt` is found in its parent run diretory.
 
 ## Running tests

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -215,7 +215,7 @@ class IlluminaDirectorySensor(PollingSensor):
 
         for state in states:
             _, stdout, _ = client.exec_command(
-                f"find {str(path)} -name {state}"
+                f"find {str(path)} -maxdepth 1 -mindepth 1 -type f -name {state}"
             )
 
             if len(stdout.read()) > 0:


### PR DESCRIPTION
This caused an issue in real sequencing directories with more depth to them, and with different permissions in different parts of the tree.