### PR TITLE
feat: use cleve for tracking run directory states

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,28 +9,20 @@ st2 pack config gmc_norr_seqdata
 
 ## Config
 
-The main config parameter that needs to be set is `illumina_directories`. This is an array of objects representing the directories in which to watch for sequencing run directories. Each entry should have the absolute path to the directory in question, and the name of the host where this directory is located. If the host name is missing or `null` it will default to `localhost`.
+The main config parameters that need to be set are `illumina_directories` and `cleve`. These should contain an array of paths to watch for new runs in and the [cleve](https://github.com/gmc-norr/cleve) configuration, respectively.
 
 Example:
 
 ```yaml
 illumina_directories:
-    - path: /data/seqdata
-      host: null # will look on localhost
-    - directory: /data/seqdata
-      host: vsXXX.vll.se
+    - /data/seqdata/novaseq
+    - /data/seqdata/nextseq
+
+cleve:
+  host: localhost
+  port: 8080
+  api_key: supersecretapikey
 ```
-
-If the illumina directory sensor will run on any remote hosts, then the `user` and `ssh_key` parameters in the config need to be defined. These default to:
-
-```yaml
-user: stanley
-ssh_key: /home/stanley/.ssh/stanley_rsa
-```
-
-The user `sensor_service` needs to be able to read and write to the key-value store, more specifically the following keys:
-
-- `gmc_norr_seqdata.IlluminaDirectorySensor:illumina_directories`
 
 ## Actions
 
@@ -48,11 +40,9 @@ IlluminaDirectorySensor | Sensor that emits triggers for seqencing run directori
 
 ref | description
 --- | ---
-copy_complete | Triggers when CopyComplete.txt is found in a directory
-new_directory | Triggers when a new directory is found
-
-> [!NOTE]
-> Note that the triggers that are connected to analysis directories will not be emitted unless `CopyComplete.txt` is found in its parent run diretory.
+incomplete_directory | Triggers when a new directory is found, but it is somehow incomplete and thus cannot be added to the database
+new_directory        | Triggers when a new directory is found
+state_change         | Triggers when the state of a directory changes
 
 ## Running tests
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -3,21 +3,29 @@
 illumina_directories:
   description: >
     The directories in which to watch for new Illumina sequencing runs.
+  required: true
   type: array
   items:
-    type: object
-    properties:
-      path:
-        description: >
-          The directory to watch for new run directories in.
-        type: string
-        required: true
-      host:
-        description: >
-          The host where the watch directory is located. By default it will
-          look on localhost.
-        type: string
-        required: false
+    description: >
+      The directory to watch for new run directories in.
+    type: string
+    required: true
+
+cleve:
+  description: >
+    Config for the accessing cleve (https://github.com/gmc-norr/cleve)
+  type: object
+  required: true
+  properties:
+    host: 
+      type: string
+      required: true
+    port:
+      type: number
+      required: true
+    api_key:
+      type: string
+      required: true
 
 user:
   description: >

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -26,17 +26,3 @@ cleve:
     api_key:
       type: string
       required: true
-
-user:
-  description: >
-    The user to use for ssh connections
-  type: string
-  required: true
-  default: stanley
-
-ssh_key:
-  description: >
-    The ssh key to use for ssh connections
-  type: string
-  required: true
-  default: /home/stanley/.ssh/stanley_rsa

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -1,0 +1,29 @@
+import requests
+from typing import Dict
+
+
+class CleveError(Exception):
+    pass
+
+
+class Cleve:
+
+    def __init__(self, host: str, port: int):
+        self.uri = f"http://{host}:{port}/api"
+
+    def get_runs(self, platform: str = None, state: str = None) -> Dict[str, Dict]:
+        uri = f"{self.uri}/runs?brief"
+        if platform:
+            uri += f"&platform={platform}"
+        if state:
+            uri += f"&state={state}"
+
+        r = requests.get(uri)
+
+        if r.status_code != 200:
+            raise CleveError(f"failed to fetch runs from {self.uri}: HTTP {r.status_code}")
+
+        runs = {}
+        for run in r.json():
+            runs[run["run_id"]] = run
+        return runs

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -1,5 +1,6 @@
 import requests
-from typing import Dict
+import time
+from typing import Dict, Optional
 
 
 class CleveError(Exception):
@@ -11,7 +12,7 @@ class Cleve:
     def __init__(self, host: str, port: int):
         self.uri = f"http://{host}:{port}/api"
 
-    def get_runs(self, platform: str = None, state: str = None) -> Dict[str, Dict]:
+    def get_runs(self, platform: Optional[str] = None, state: Optional[str] = None) -> Dict[str, Dict]:
         uri = f"{self.uri}/runs?brief"
         if platform:
             uri += f"&platform={platform}"
@@ -27,3 +28,40 @@ class Cleve:
         for run in r.json():
             runs[run["run_id"]] = run
         return runs
+
+
+class CleveMock(Cleve):
+
+    def __init__(self, runs: Optional[Dict[str, Dict]] = None):
+        self.runs = {}
+        if runs is not None:
+            self.runs = runs
+
+    def get_runs(self, platform: Optional[str] = None, state: Optional[str] = None) -> Dict[str, Dict]:
+        runs = {}
+        for run_id, run in self.runs.items():
+            last_state = sorted(run["state_history"], key=lambda x: x["time"], reverse=True)[0]["state"]
+            if platform and run["platform"] != platform:
+                continue
+            if state and last_state != state:
+                continue
+            runs[run_id] = run
+        return runs
+
+    def add_run(self, run: Dict):
+        if "run_id" not in run:
+            raise CleveError("run must have a run_id")
+        if "state_history" not in run:
+            raise CleveError("run must have a state_history")
+        if "platform" not in run:
+            raise CleveError("run must have a platform")
+        self.runs[run["run_id"]] = run
+
+    def update_run(self, run_id: str, state: Optional[str] = None, analysis: Optional[Dict] = None):
+        if run_id not in self.runs:
+            raise CleveError(f"run {run_id} not found")
+
+        if state is not None:
+            self.runs[run_id]["state_history"].append({"state": state, "time": time.time()})
+        if analysis is not None:
+            self.runs[run_id]["analysis"].append(analysis)

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -33,6 +33,7 @@ class Cleve:
 class CleveMock(Cleve):
 
     def __init__(self, runs: Optional[Dict[str, Dict]] = None):
+        self.key = "supersecretapikey"
         self.runs = {}
         if runs is not None:
             self.runs = runs
@@ -48,7 +49,9 @@ class CleveMock(Cleve):
             runs[run_id] = run
         return runs
 
-    def add_run(self, run: Dict):
+    def add_run(self, key: str, run: Dict):
+        if key != self.key:
+            raise CleveError("invalid API key")
         if "run_id" not in run:
             raise CleveError("run must have a run_id")
         if "state_history" not in run:
@@ -57,7 +60,9 @@ class CleveMock(Cleve):
             raise CleveError("run must have a platform")
         self.runs[run["run_id"]] = run
 
-    def update_run(self, run_id: str, state: Optional[str] = None, analysis: Optional[Dict] = None):
+    def update_run(self, key: str, run_id: str, state: Optional[str] = None, analysis: Optional[Dict] = None):
+        if key != self.key:
+            raise CleveError("invalid API key")
         if run_id not in self.runs:
             raise CleveError(f"run {run_id} not found")
 

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -1,47 +1,36 @@
-from io import StringIO
-import json
 import os
 from pathlib import Path
-import paramiko
-from paramiko.client import SSHClient, AutoAddPolicy
-import pwd
+import requests
 from st2reactor.sensor.base import PollingSensor
-import subprocess
-from typing import Dict, List, Union
+from typing import Dict
+import xml.etree.ElementTree as ET
 
 
-class LocalHostClient:
-
-    def __init__(self, username):
-        self.hostname = "localhost"
-
-        if username is None:
-            self.user_uid = os.getuid()
-            self.user_gid = os.getgid()
-        else:
-            pw_record = pwd.getpwnam(username)
-            self.user_uid = pw_record.pw_uid
-            self.user_gid = pw_record.pw_gid
-
-    def exec_command(self, cmd):
-        if isinstance(cmd, str):
-            cmd = cmd.split()
-        p = subprocess.run(cmd, preexec_fn=self._preexec, encoding="utf-8",
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                           check=True)
-        return "", StringIO(p.stdout), StringIO(p.stderr)
-
-    def _preexec(self):
-        os.setgid(self.user_gid)
-        os.setuid(self.user_uid)
-
-    def close(self):
-        pass
+PLATFORMS = {
+    "NovaSeq": {
+        "serial_tag": "InstrumentSerialNumber",
+        "serial_pattern": "LH",
+        "ready_marker": "CopyComplete.txt",
+    },
+    "NextSeq": {
+        "serial_tag": "InstrumentId",
+        "serial_pattern": "NB",
+        "ready_marker": "CopyComplete.txt",
+    },
+    "MiSeq": {
+        "serial_tag": "ScannerID",
+        "serial_pattern": "M",
+        "ready_marker": "RTAComplete.txt",
+    },
+}
 
 
 class DirectoryState:
-    COPYCOMPLETE = "CopyComplete.txt"
+    NEW = "new"
+    READY = "ready"
+    PENDING = "pending"
     UNDEFINED = "undefined"
+    INCOMPLETE = "incomplete"
 
 
 class DirectoryType:
@@ -50,151 +39,200 @@ class DirectoryType:
 
 
 class IlluminaDirectorySensor(PollingSensor):
-    _DATASTORE_KEY = "illumina_directories"
-    _dispatched_directories: List[Dict[str, str]]
 
     def __init__(self, sensor_service, config=None, poll_interval=60):
         super(IlluminaDirectorySensor, self).__init__(sensor_service, config, poll_interval)
         self._logger = self.sensor_service.get_logger(__name__)
-        self._watched_directories = self.config.get(self._DATASTORE_KEY, [])
+        self._watched_directories = self.config.get("illumina_directories", [])
         self._directories = {}
+
+        cleve_host = self.config.get("cleve", {}).get("host")
+        cleve_port = self.config.get("cleve", {}).get("port")
+        self.cleve_uri = f"http://{cleve_host}:{cleve_port}/api"
 
         self._logger.debug("watched directories:")
         for wd in self._watched_directories:
             self._logger.debug(f"  - {wd}")
 
-        directories = self.sensor_service.get_value(self._DATASTORE_KEY)
-        if directories is not None:
-            for rd in json.loads(directories):
-                self._directories[f"{rd['host']}:{rd['path']}"] = rd
-
     def setup(self):
         pass
 
     def poll(self):
-        self._check_for_run()
+        """
+        Poll the file system for new run and analysis directories
+        as well as state changes of existing directories.
+        """
+        registered_rundirs = self._get_existing_runs()
+        self._check_for_run(registered_rundirs)
         self._check_for_analysis()
-        self._update_datastore()
 
-    def _check_for_run(self):
-        existing_directories = set()
+    def _get_existing_runs(self) -> Dict[str, Dict]:
+        """
+        Get existing run directories.
 
-        # TODO: group watched directories by host and process each as a unit
+        :return: Existing run directories
+        :rtype: dict
+        """
+        uri = f"{self.cleve_uri}/runs?brief"
 
+        r = requests.get(uri)
+        if r.status_code != 200:
+            self._logger.error(f"Failed to get existing runs: {r.status_code}")
+            raise RuntimeError(f"failed to fetch runs from {uri}")
+
+        runs = r.json()
+
+        rundirs = {}
+        for run in runs:
+            rundirs[run["run_id"]] = run
+
+        return rundirs
+
+    def _check_for_run(self, registered_rundirs: Dict[str, Dict]) -> None:
+        """
+        Check for new run directories, or state changes of existing run
+        directories.
+
+        Emits triggers for new run directories, state changes of existing run
+        directories, and also incomplete run directories where essential
+        information is missing.
+
+        :param registered_rundirs: Existing run directories
+        :type registered_rundirs: dict
+        """
         for wd in self._watched_directories:
-            self._logger.debug(f"checking watch directory: {wd['path']}")
+            self._logger.debug(f"checking watch directory: {wd}")
 
-            host = wd.get("host", "localhost") or "localhost"
-            client = self._client(host)
+            root, dirnames, _ = next(os.walk(wd))
 
-            _, stdout, stderr = client.exec_command(
-                f"find {wd['path']} -maxdepth 1 -mindepth 1 -type d"
-            )
-
-            # Add new directories or update state of existing directories
-            for line in stdout:
-                directory_path = Path(line.strip())
-                directory_state = self.directory_state(directory_path, client)
-
-                payload = {
-                    "path": str(directory_path),
-                    "host": host,
-                    "type": DirectoryType.RUN,
-                }
-
-                existing_directories.add(f"{host}:{directory_path}")
-                existing_directory = self._find_directory(directory_path, host)
-                state_changed = False
-
-                if existing_directory is None:
-                    state_changed = True
-                    self._add_directory(directory_path, host, directory_state, DirectoryType.RUN)
-                    self.sensor_service.dispatch(
-                        trigger="gmc_norr_seqdata.new_directory",
-                        payload=payload
+            for dirname in dirnames:
+                dirpath = Path(root) / str(dirname)
+                self._logger.debug(f"looking at {dirpath}")
+                try:
+                    run_id = self.get_run_id(dirpath)
+                except IOError as e:
+                    self._logger.debug(f"incomplete run directory: {str(e)}")
+                    self._emit_trigger(
+                        "incomplete_directory",
+                        dirpath,
+                        DirectoryState.INCOMPLETE,
+                        DirectoryType.RUN,
+                        message=str(e),
                     )
+                    continue
+                self._logger.debug(f"identified run as {run_id}")
+                if run_id in registered_rundirs:
+                    registered_state = registered_rundirs[run_id]["state_history"][0]["state"]
+                    current_state = self.directory_state(dirpath)
+
+                    print(registered_state, current_state)
+
+                    if registered_state != current_state:
+                        self._logger.debug(f"{dirpath} changed state from {registered_state} to {current_state}")
+                        self._emit_trigger("state_change", dirpath, current_state, DirectoryType.RUN)
                 else:
-                    state_changed = existing_directory["state"] != directory_state
-                    existing_directory["state"] = directory_state
-
-                if state_changed:
-                    if directory_state == DirectoryState.COPYCOMPLETE:
-                        self.sensor_service.dispatch(
-                            trigger="gmc_norr_seqdata.copy_complete",
-                            payload=payload,
-                        )
-
-            for line in stderr:
-                self._logger.warning(f"stderr: {line}")
-
-            client.close()
-
-        # Remove directories that no longer exist
-        for k in set(self._directories.keys()) - existing_directories:
-            self._logger.debug(f"removing directory: {self._directories[k]}")
-            self._directories.pop(k)
+                    self._logger.debug(f"new directory found: {dirpath}")
+                    self._emit_trigger("new_directory", dirpath, DirectoryState.NEW, DirectoryType.RUN)
 
     def _check_for_analysis(self):
         """
-        Check for an analysis directory inside run directories that are COPYCOMPLETE.
+        Check for an analysis directory inside NovaSeq run directories that
+        are ready.
         """
-        existing_directories = set()
-        run_directories = [rd for rd in self._directories.values() if rd["type"] == DirectoryType.RUN and rd["state"] == DirectoryState.COPYCOMPLETE]
+        uri = f"{self.cleve_uri}/runs?platform=NovaSeq&state=ready"
+        r = requests.get(uri)
+        if r.status_code != 200:
+            self._logger.error(f"Failed to get existing runs: {r.status_code}")
+            raise RuntimeError(f"failed to fetch runs from {uri}")
 
-        for rd in run_directories:
-            if rd["type"] != DirectoryType.RUN or rd["state"] != DirectoryState.COPYCOMPLETE:
+        runs = r.json()
+
+        self._logger.debug(f"found {len(runs)} ready NovaSeq runs")
+
+        for run in runs:
+            print(run["path"])
+            analysis_path = Path(run["path"]) / "Analysis"
+            if not analysis_path.is_dir():
+                # There are no analysis directories to check
                 continue
-            self._logger.debug(f"checking for analysis directory in {rd['host']}{rd['path']}")
+            existing_analyses = {}
+            for analysis in run.get("analysis", []):
+                existing_analyses[analysis["path"]] = analysis
 
-            host = rd.get("host", "localhost") or "localhost"
-            client = self._client(host)
+            root, analysis_dirs, _ = next(os.walk(analysis_path))
 
-            _, stdout, stderr = client.exec_command(
-                f"find {rd['path']} -maxdepth 1 -mindepth 1 -type d -name Analysis"
-            )
+            for analysis_dir in analysis_dirs:
+                dirpath = Path(root) / str(analysis_dir)
+                self._logger.debug(f"looking at analysis at {dirpath}")
+                if dirpath in existing_analyses:
+                    self._logger.debug(f"analysis dir has been registered for run, checking state")
+                    registered_state = existing_analyses[dirpath]["state"]
+                    current_state = self.directory_state(dirpath)
+                    if registered_state != current_state:
+                        self._logger.debug(f"{dirpath} changed state from {registered_state} to {current_state}")
+                        self._emit_trigger("state_change", dirpath, current_state, DirectoryType.ANALYSIS)
+                else:
+                    self._logger.debug(f"new analysis found: {dirpath}")
+                    self._emit_trigger("new_directory", dirpath, self.directory_state(dirpath), DirectoryType.ANALYSIS)
 
-            analysis_dir = stdout.read().strip()
-            if not analysis_dir:
+    def _emit_trigger(self, trigger: str, path: Path, state: str, type: str, message: str = ""):
+        """
+        Emit a stackstorm trigger.
+
+        :param trigger: The trigger name
+        :type trigger: str
+        :param path: The path to the directory
+        :type path: pathlib.Path
+        :param state: The directory state
+        :type state: str
+        :param type: The directory type
+        :type type: str
+        :param message: An optional message
+        :type message: str
+        """
+        payload = {
+            "path": str(path),
+            "state": state,
+            "type": type,
+            "message": message,
+        }
+        self.sensor_service.dispatch(trigger=f"gmc_norr_seqdata.{trigger}", payload=payload)
+
+    def get_run_id(self, path: Path) -> str:
+        """
+        Get the sequencing run ID from RunParameters.xml.
+
+        :param path: The path to the sequencing run directory
+        :type path: pathlib.Path
+        :raises ValueError: If the sequencing platform or run ID cannot be identified
+        :return: The run ID.
+        :rtype: str
+        """
+        self._logger.debug(f"looking for run id in {path}")
+        runparamsfile = path / "RunParameters.xml"
+        if not runparamsfile.is_file():
+            raise IOError(f"{runparamsfile} does not exist")
+        tree = ET.parse(runparamsfile)
+        root = tree.getroot()
+
+        for p, d in PLATFORMS.items():
+            serialelem = root.find(d["serial_tag"])
+            if serialelem is None:
                 continue
+            serial = str(serialelem.text)
+            platform = p
+            if not serial.startswith(d["serial_pattern"]):
+                raise ValueError(f"Serial number {serial} does not belong to {platform}")
+            break
+        else:
+            raise ValueError("Could not identify platform")
 
-            _, stdout, stderr = client.exec_command(
-                f"find {analysis_dir} -maxdepth 1 -mindepth 1 -type f -name CopyComplete.txt"
-            )
+        self._logger.debug(f"platform is {platform}")
 
-            directory_state = self.directory_state(str(analysis_dir), client)
-
-            existing_directories.add(f"{host}:{analysis_dir}")
-            existing_directory = self._find_directory(str(analysis_dir), host)
-            state_changed = False
-
-            payload = {
-                "path": analysis_dir,
-                "host": host,
-                "type": DirectoryType.ANALYSIS,
-            }
-
-            if existing_directory is None:
-                state_changed = True
-                self._add_directory(analysis_dir, host, directory_state, DirectoryType.ANALYSIS)
-                self.sensor_service.dispatch(
-                    trigger="gmc_norr_seqdata.new_directory",
-                    payload=payload
-                )
-            else:
-                state_changed = existing_directory["state"] != directory_state
-                existing_directory["state"] = directory_state
-
-            if state_changed:
-                for line in stderr:
-                    self._logger.warning(f"stderr: {line}")
-
-                if directory_state == DirectoryState.COPYCOMPLETE:
-                    self.sensor_service.dispatch(
-                        trigger="gmc_norr_seqdata.copy_complete",
-                        payload=payload,
-                    )
-
-            client.close()
+        run_id = root.find("RunId")
+        if run_id is None:
+            raise ValueError(f"RunId not found in {runparamsfile}")
+        return str(run_id.text)
 
     def cleanup(self):
         pass
@@ -208,60 +246,33 @@ class IlluminaDirectorySensor(PollingSensor):
     def remove_trigger(self, trigger):
         pass
 
-    def directory_state(self, path: Union[Path, str], client: Union[SSHClient, LocalHostClient]):
-        states = [
-            DirectoryState.COPYCOMPLETE,
-        ]
+    def directory_state(self, path: Path) -> str:
+        """
+        Get the state of a directory
 
-        for state in states:
-            _, stdout, _ = client.exec_command(
-                f"find {str(path)} -maxdepth 1 -mindepth 1 -type f -name {state}"
-            )
+        If a directory contains a RunParameters.xml file and a CopyComplete.txt
+        file, then the directory is ready for analysis.
 
-            if len(stdout.read()) > 0:
-                return state
+        If the directory only contains a RunParameters.xml file, processing on
+        the machine is not yet complete, so the directory is pending.
 
-        return DirectoryState.UNDEFINED
+        If the directory contains neither a RunParameters.xml file nor a
+        CopyComplete.txt file, then the directory is incomplete and will not
+        be added to the database.
 
-    def _client(self, hostname: str):
-        user = self.config.get("user")
-        keyfile = self.config.get("ssh_key")
+        :param path: The path to the run directory
+        :type path: pathlib.Path
+        :return: The state of the directory
+        :rtype: str
+        """
+        runparams = path / "RunParameters.xml"
+        copycomplete = path / "CopyComplete.txt"
 
-        self._logger.debug(f"connecting to {hostname} as {user}")
-
-        if hostname == "localhost":
-            client = LocalHostClient(user)
+        if runparams.is_file() and copycomplete.is_file():
+            return DirectoryState.READY
+        elif runparams.is_file() and not copycomplete.exists():
+            return DirectoryState.PENDING
+        elif not runparams.is_file():
+            return DirectoryState.INCOMPLETE
         else:
-            client = SSHClient()
-            client.set_missing_host_key_policy(AutoAddPolicy)
-
-            try:
-                client.connect(
-                    hostname=hostname,
-                    username=user,
-                    key_filename=keyfile,
-                )
-            except paramiko.ssh_exception.AuthenticationException as e:
-                self._logger.error(f"Authentication failed for {user}@{hostname}: {e}")
-                raise RuntimeError
-
-        return client
-
-    def _add_directory(self, directory: Path, host: str, state: str, type: str):
-        self._logger.debug(f"adding directory: {host}:{directory}")
-        self._directories[f"{host}:{str(directory)}"] = {
-            "path": str(directory),
-            "host": host,
-            "state": state,
-            "type": type,
-        }
-
-    def _find_directory(self, directory: Union[Path, str], host: str):
-        return self._directories.get(f"{host}:{str(directory)}", None)
-
-    def _update_datastore(self):
-        self._logger.debug("updating datastore with directories")
-        self.sensor_service.set_value(
-            self._DATASTORE_KEY,
-            json.dumps(list(self._directories.values()))
-        )
+            return DirectoryState.UNDEFINED

--- a/sensors/illumina_directory_sensor.yaml
+++ b/sensors/illumina_directory_sensor.yaml
@@ -8,23 +8,26 @@ description: >
 poll_interval: 60
 enabled: false
 trigger_types:
-  - name: copy_complete
+  - name: state_change
     pack: gmc_norr_seqdata
     description: >
-      Triggers when CopyComplete.txt is found in a directory
+      Triggers when the state of a directory changes
     payload_schema:
       type: object
       properties:
         path:
           type: string
-          description: The directory in which the copycomplete file was found
-        host:
+          description: The directory whose state has changed
+        state:
           type: string
-          description: The host on which the directory was found
-        type:
+          description: The state of the directory
+        directory_type:
           type: string
           description: The type of directory
           enum: [run, analysis]
+        message:
+          type: string
+          description: A message associated with the state change
 
   - name: new_directory
     pack: gmc_norr_seqdata
@@ -36,10 +39,35 @@ trigger_types:
         path:
           type: string
           description: The path to the new directory
-        host:
+        state:
           type: string
-          description: The host on which the new directory was found
-        type:
+          description: The state of the directory
+        directory_type:
           type: string
           description: The type of directory
           enum: [run, analysis]
+        message:
+          type: string
+          description: A message associated with the state change
+
+  - name: incomplete_directory
+    pack: gmc_norr_seqdata
+    description: >
+      Triggers when a new directory is found, but it is somehow incomplete
+    payload_schema:
+      type: object
+      properties:
+        path:
+          type: string
+          description: The path to the directory
+        state:
+          type: string
+          description: The state of the directory
+          const: incomplete
+        directory_type:
+          type: string
+          description: The type of directory
+          enum: [run, analysis]
+        message:
+          type: string
+          description: A message describing why the directory is incomplete

--- a/sensors/illumina_directory_sensor.yaml
+++ b/sensors/illumina_directory_sensor.yaml
@@ -15,6 +15,9 @@ trigger_types:
     payload_schema:
       type: object
       properties:
+        run_id:
+          type: string
+          description: The ID of the run
         path:
           type: string
           description: The directory whose state has changed
@@ -36,6 +39,9 @@ trigger_types:
     payload_schema:
       type: object
       properties:
+        run_id:
+          type: string
+          description: The ID of the run
         path:
           type: string
           description: The path to the new directory
@@ -58,6 +64,9 @@ trigger_types:
     payload_schema:
       type: object
       properties:
+        run_id:
+          type: null
+          description: The ID of the run, which cannot be determined if it is incomplete
         path:
           type: string
           description: The path to the directory

--- a/sensors/illumina_directory_sensor.yaml
+++ b/sensors/illumina_directory_sensor.yaml
@@ -65,8 +65,9 @@ trigger_types:
       type: object
       properties:
         run_id:
-          type: null
+          type: string
           description: The ID of the run, which cannot be determined if it is incomplete
+          const: null
         path:
           type: string
           description: The path to the directory

--- a/sensors/illumina_directory_sensor.yaml
+++ b/sensors/illumina_directory_sensor.yaml
@@ -54,6 +54,7 @@ trigger_types:
     pack: gmc_norr_seqdata
     description: >
       Triggers when a new directory is found, but it is somehow incomplete
+      and thus cannot be added to the database.
     payload_schema:
       type: object
       properties:
@@ -63,7 +64,7 @@ trigger_types:
         state:
           type: string
           description: The state of the directory
-          const: incomplete
+          enum: [incomplete, error]
         directory_type:
           type: string
           description: The type of directory

--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -70,6 +70,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.assertTriggerDispatched(
             trigger="gmc_norr_seqdata.incomplete_directory",
             payload={
+                "run_id": None,
                 "path": str(run_dirs[0]),
                 "state": DirectoryState.INCOMPLETE,
                 "type": DirectoryType.RUN,
@@ -83,6 +84,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.assertTriggerDispatched(
             trigger="gmc_norr_seqdata.incomplete_directory",
             payload={
+                "run_id": None,
                 "path": str(run_dirs[0]),
                 "state": DirectoryState.ERROR,
                 "type": DirectoryType.RUN,
@@ -97,6 +99,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.assertTriggerDispatched(
             trigger="gmc_norr_seqdata.new_directory",
             payload={
+                "run_id": "run1",
                 "path": str(run_dirs[0]),
                 "state": DirectoryState.PENDING,
                 "type": DirectoryType.RUN,
@@ -118,6 +121,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.assertTriggerDispatched(
             trigger="gmc_norr_seqdata.state_change",
             payload={
+                "run_id": "run1",
                 "path": str(run_dirs[0]),
                 "state": DirectoryState.READY,
                 "type": DirectoryType.RUN,
@@ -139,6 +143,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.assertTriggerDispatched(
             trigger="gmc_norr_seqdata.state_change",
             payload={
+                "run_id": "run1",
                 "path": str(Path(self.watch_directories[0].name) / "run1"),
                 "state": DirectoryState.MOVED,
                 "type": DirectoryType.RUN,
@@ -160,6 +165,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.assertTriggerDispatched(
             trigger="gmc_norr_seqdata.new_directory",
             payload={
+                "run_id": "run1",
                 "path": str(run_directory),
                 "state": DirectoryState.READY,
                 "type": DirectoryType.RUN,
@@ -183,6 +189,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.assertTriggerDispatched(
             trigger="gmc_norr_seqdata.new_directory",
             payload={
+                "run_id": "run1",
                 "path": str(analysis_directory),
                 "state": DirectoryState.PENDING,
                 "type": DirectoryType.ANALYSIS,
@@ -205,6 +212,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.assertTriggerDispatched(
             trigger="gmc_norr_seqdata.state_change",
             payload={
+                "run_id": "run1",
                 "path": str(analysis_directory),
                 "state": DirectoryState.READY,
                 "type": DirectoryType.ANALYSIS,

--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -104,7 +104,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         )
 
         # Add the run to the database
-        self.cleve.add_run({
+        self.cleve.add_run("supersecretapikey", {
             "run_id": "run1",
             "platform": "NovaSeq",
             "state_history": [{"state": "new", "time": time.localtime()}],
@@ -128,7 +128,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.assertEqual(len(self.get_dispatched_triggers()), 4)
 
     def test_moved_run_directory(self):
-        self.cleve.add_run({
+        self.cleve.add_run("supersecretapikey", {
             "run_id": "run1",
             "platform": "NovaSeq",
             "state_history": [{"state": "new", "time": time.localtime()}],
@@ -154,7 +154,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self._write_basic_runparams(run_directory, "NovaSeq", "run1")
         (run_directory / "CopyComplete.txt").touch()
 
-        self.cleve.add_run({
+        self.cleve.add_run("supersecretapikey", {
             "run_id": "run1",
             "platform": "NovaSeq",
             "state_history": [{"state": "ready", "time": time.localtime()}],
@@ -181,7 +181,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self._write_basic_runparams(run_directory, "NovaSeq", "run1")
         (run_directory / "CopyComplete.txt").touch()
 
-        self.cleve.add_run({
+        self.cleve.add_run("supersecretapikey", {
             "run_id": "run1",
             "platform": "NovaSeq",
             "state_history": [{"state": "new", "time": time.localtime()}],
@@ -242,7 +242,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         )
 
         # Add the run to the database
-        self.cleve.add_run({
+        self.cleve.add_run("supersecretapikey", {
             "run_id": "run1",
             "platform": "NovaSeq",
             "state_history": [{
@@ -255,6 +255,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
 
         # Add analysis directory to database
         self.cleve.update_run(
+            key="supersecretapikey",
             run_id="run1",
             analysis={
                 "path": str(analysis_directory),


### PR DESCRIPTION
This PR represents a reworked sensor that uses the sequencing database API (cleve) for keeping track of the state of run directories instead of using the key-value store in Stackstorm. Currently it only reads from the database, and the idea is that writes will be handled by actions downstream from this sensor.