### PR TITLE
feat: add rules and actions for handling sequencing runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ cleve:
 
 ## Actions
 
+ref | description
+--- | ---
+add_analysis     | Add an analysis associated with a sequencing run
+add_run          | Add a sequencing run to the database
+update_analysis  | Update an analysis associated with a NovaSeq sequencing run
+update_run_state | Update the state of a run
 
 ## Rules
 
@@ -36,7 +42,6 @@ add_run_directory      | Rule for adding a new sequencing run directory
 notify_incomplete      | Rule for sending an email when an incomplete run directory is found
 update_analysis        | Rule for updating the state and summary for an existing analysis
 update_run_state       | Rule for updating the state of an existing sequencing run
-
 
 ## Sensors
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ st2 pack config gmc_norr_seqdata
 
 ## Config
 
-The main config parameters that need to be set are `illumina_directories` and `cleve`. These should contain an array of paths to watch for new runs in and the [cleve](https://github.com/gmc-norr/cleve) configuration, respectively.
+The main config parameters that need to be set are `illumina_directories`, `notification_email` and `cleve`. These should contain an array of paths to watch for new runs in, an array of email addresses where notifications should be sent and the [cleve](https://github.com/gmc-norr/cleve) configuration, respectively.
 
 Example:
 
@@ -17,6 +17,9 @@ Example:
 illumina_directories:
     - /data/seqdata/novaseq
     - /data/seqdata/nextseq
+
+notification_email:
+  - me@email.com
 
 cleve:
   host: localhost

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ cleve:
 
 ## Rules
 
+ref | description
+--- | ---
+add_analysis_directory | Rule for adding an analysis directory to an exising NovaSeq run
+add_run_directory      | Rule for adding a new sequencing run directory
+notify_incomplete      | Rule for sending an email when an incomplete run directory is found
+update_analysis        | Rule for updating the state and summary for an existing analysis
+update_run_state       | Rule for updating the state of an existing sequencing run
+
 
 ## Sensors
 

--- a/actions/add_analysis.py
+++ b/actions/add_analysis.py
@@ -1,6 +1,6 @@
 from cleve_service import Cleve
 from st2common.runners.base_action import Action
-from typing import Optional
+from typing import Any, Dict, Optional
 
 
 class AddAnalysisAction(Action):
@@ -17,10 +17,10 @@ class AddAnalysisAction(Action):
             run_id: str,
             path: str,
             state: str,
-            summary_file: Optional[str]) -> None:
-        self.cleve.add_analysis(
-            run_id,
+            summary_file: Optional[str]) -> Dict[str, Any]:
+        return self.cleve.add_analysis(
+            run_id=run_id,
             path=path,
             state=state,
-            summary_file=summary_file
+            summary_file=summary_file,
         )

--- a/actions/add_analysis.py
+++ b/actions/add_analysis.py
@@ -1,5 +1,6 @@
 from cleve_service import Cleve
 from st2common.runners.base_action import Action
+from typing import Optional
 
 
 class AddAnalysisAction(Action):
@@ -16,7 +17,7 @@ class AddAnalysisAction(Action):
             run_id: str,
             path: str,
             state: str,
-            summary_file: str) -> None:
+            summary_file: Optional[str]) -> None:
         self.cleve.add_analysis(
             run_id,
             path=path,

--- a/actions/add_analysis.py
+++ b/actions/add_analysis.py
@@ -1,0 +1,25 @@
+from cleve_service import Cleve
+from st2common.runners.base_action import Action
+
+
+class AddAnalysisAction(Action):
+
+    def __init__(self, config, action_service):
+        super().__init__(config, action_service)
+        self.cleve = Cleve(
+            config.get("cleve").get("host"),
+            config.get("cleve").get("port"),
+            config.get("cleve").get("api_key"),
+        )
+
+    def run(self,
+            run_id: str,
+            path: str,
+            state: str,
+            summary_file: str) -> None:
+        self.cleve.add_analysis(
+            run_id,
+            path=path,
+            state=state,
+            summary_file=summary_file
+        )

--- a/actions/add_analysis.yaml
+++ b/actions/add_analysis.yaml
@@ -24,5 +24,5 @@ parameters:
   summary_file:
     type: string
     description: The path to the summary JSON
-    required: true
+    required: false
     position: 3

--- a/actions/add_analysis.yaml
+++ b/actions/add_analysis.yaml
@@ -1,0 +1,28 @@
+---
+name: add_analysis
+runner_type: python-script
+description: Add an analysis associated with a sequencing run
+enabled: true
+entry_point: add_analysis.py
+
+parameters:
+  run_id:
+    type: string
+    description: The ID of the run
+    required: true
+    position: 0
+  path:
+    type: string
+    description: The path to the analysis directory
+    required: true
+    position: 1
+  state:
+    type: string
+    description: The state of the run
+    required: true
+    position: 2
+  summary_file:
+    type: string
+    description: The path to the summary JSON
+    required: true
+    position: 3

--- a/actions/add_run.py
+++ b/actions/add_run.py
@@ -1,5 +1,6 @@
 import cleve_service
 from st2common.runners.base_action import Action
+from typing import Any, Dict
 
 
 class AddRunAction(Action):
@@ -15,5 +16,9 @@ class AddRunAction(Action):
     def run(self,
             runparameters: str,
             path: str,
-            state: str) -> None:
-        self.cleve.add_run(runparameters, path, state)
+            state: str) -> Dict[str, Any]:
+        return self.cleve.add_run(
+            runparameters=runparameters,
+            path=path,
+            state=state,
+        )

--- a/actions/add_run.py
+++ b/actions/add_run.py
@@ -1,0 +1,19 @@
+import cleve_service
+from st2common.runners.base_action import Action
+
+
+class AddRunAction(Action):
+
+    def __init__(self, config, action_service):
+        super().__init__(config, action_service)
+        self.cleve = cleve_service.Cleve(
+            config.get("cleve").get("host"),
+            config.get("cleve").get("port"),
+            config.get("cleve").get("api_key"),
+        )
+
+    def run(self,
+            runparameters: str,
+            path: str,
+            state: str) -> None:
+        self.cleve.add_run(runparameters, path, state)

--- a/actions/add_run.yaml
+++ b/actions/add_run.yaml
@@ -1,0 +1,23 @@
+---
+name: add_run
+runner_type: python-script
+description: Add a sequencing run to the database
+enabled: true
+entry_point: add_run.py
+
+parameters:
+  path:
+    type: string
+    description: The path to the run directory
+    required: true
+    position: 0
+  state:
+    type: string
+    description: The detected state of the directory
+    required: true
+    position: 1
+  runparameters:
+    type: string
+    description: Path to the runparameters file
+    required: true
+    position: 2

--- a/actions/update_analysis.py
+++ b/actions/update_analysis.py
@@ -1,6 +1,6 @@
 from cleve_service import Cleve
 from st2common.runners.base_action import Action
-from typing import Optional
+from typing import Any, Dict, Optional
 
 
 class UpdateAnalysisAction(Action):
@@ -17,10 +17,10 @@ class UpdateAnalysisAction(Action):
             run_id: str,
             path: str,
             state: str,
-            summary_file: Optional[str] = None) -> None:
-        self.cleve.update_analysis(
-            run_id,
+            summary_file: Optional[str] = None) -> Dict[str, Any]:
+        return self.cleve.update_analysis(
+            run_id=run_id,
             state=state,
             path=path,
-            summary_file=summary_file
+            summary_file=summary_file,
         )

--- a/actions/update_analysis.py
+++ b/actions/update_analysis.py
@@ -1,0 +1,26 @@
+from cleve_service import Cleve
+from st2common.runners.base_action import Action
+from typing import Optional
+
+
+class UpdateAnalysisAction(Action):
+
+    def __init__(self, action_service, config):
+        super().__init__(action_service, config)
+        self.cleve = Cleve(
+            config.get("cleve").get("host"),
+            config.get("cleve").get("port"),
+            config.get("cleve").get("api_key"),
+        )
+
+    def run(self,
+            run_id: str,
+            path: str,
+            state: str,
+            summary_file: Optional[str] = None) -> None:
+        self.cleve.update_analysis(
+            run_id,
+            state=state,
+            path=path,
+            summary_file=summary_file
+        )

--- a/actions/update_analysis.yaml
+++ b/actions/update_analysis.yaml
@@ -1,0 +1,23 @@
+---
+name: update_analysis
+runner_type: python-script
+description: Update an analysis associated with a NovaSeq sequencing run
+enabled: true
+entry_point: update_analysis.py
+parameters:
+  run_id:
+    type: string
+    description: The ID of the run
+    required: true
+  analysis_id:
+    type: string
+    description: The ID of the analysis to update
+    required: true
+  state:
+    type: string
+    description: The state of the run
+    required: false
+  summary_file:
+    type: string
+    description: The path to the summary JSON
+    required: false

--- a/actions/update_run_state.py
+++ b/actions/update_run_state.py
@@ -1,5 +1,6 @@
 from cleve_service import Cleve
 from st2common.runners.base_action import Action
+from typing import Any, Dict
 
 
 class UpdateRunState(Action):
@@ -12,5 +13,8 @@ class UpdateRunState(Action):
             config.get("cleve").get("api_key"),
         )
 
-    def run(self, run_id: str, state: str) -> None:
-        self.cleve.update_run(run_id, state=state)
+    def run(self, run_id: str, state: str) -> Dict[str, Any]:
+        return self.cleve.update_run(
+            run_id=run_id,
+            state=state,
+        )

--- a/actions/update_run_state.py
+++ b/actions/update_run_state.py
@@ -1,0 +1,16 @@
+from cleve_service import Cleve
+from st2common.runners.base_action import Action
+
+
+class UpdateRunState(Action):
+
+    def __init__(self, config, action_service):
+        super().__init__(config, action_service)
+        self.cleve = Cleve(
+            config.get("cleve").get("host"),
+            config.get("cleve").get("port"),
+            config.get("cleve").get("api_key"),
+        )
+
+    def run(self, run_id: str, state: str) -> None:
+        self.cleve.update_run(run_id, state=state)

--- a/actions/update_run_state.yaml
+++ b/actions/update_run_state.yaml
@@ -1,0 +1,18 @@
+---
+name: update_run_state
+runner_type: python-script
+description: Update the state of a run
+enabled: true
+entry_point: update_run_state.py
+
+parameters:
+  run_id:
+    type: string
+    description: The ID of the run
+    position: 0
+    required: true
+  state:
+    type: string
+    description: The state of the run
+    position: 1
+    required: true

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,5 +1,4 @@
 ---
-# TODO: Make it possible to define what files triggers should be emitted for
 illumina_directories:
   description: >
     The directories in which to watch for new Illumina sequencing runs.
@@ -10,6 +9,17 @@ illumina_directories:
       The directory to watch for new run directories in.
     type: string
     required: true
+
+notification_email:
+  description: >
+    The email addresses to send notifications to.
+  type: array
+  required: true
+  default: []
+  items:
+    description: An email address
+    type: string
+    format: email
 
 cleve:
   description: >

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -1,6 +1,6 @@
 import requests
 import time
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 
 class CleveError(Exception):
@@ -98,24 +98,23 @@ class Cleve:
             raise CleveError("no API key provided")
 
         uri = f"{self.uri}/runs/{run_id}/analysis"
-        headers = {"Authorization": self.key}
-
-        payload = {
-            "state": state,
-            "path": path,
+        headers = {
+            "Authorization": self.key,
         }
 
-        files = None
-        if summary_file is not None:
-            files = [(
-                "analysis_summary", (
-                    "detailed_summary.json",
-                    open(summary_file, "rb"),
-                    "application/json",
-                ),
-            )]
+        files: Dict[str, Any] = {
+            "state": (None, state),
+            "path": (None, path),
+        }
 
-        r = requests.post(uri, data=payload, files=files, headers=headers)
+        if summary_file is not None:
+            files["summary_file"] = (
+                "detailed_summary.json",
+                open(summary_file, "rb"),
+                "application/json",
+            )
+
+        r = requests.post(uri, files=files, headers=headers)
 
         print(r.json())
 

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -89,6 +89,80 @@ class Cleve:
                 f"HTTP {r.status_code} {r.json()}"
             )
 
+    def add_analysis(self,
+                     run_id: str,
+                     path: str,
+                     state: str,
+                     summary_file: Optional[str]) -> None:
+        if self.key is None:
+            raise CleveError("no API key provided")
+
+        uri = f"{self.uri}/runs/{run_id}/analysis"
+        headers = {"Authorization": self.key}
+
+        payload = {
+            "state": state,
+            "path": path,
+        }
+
+        files = None
+        if summary_file is not None:
+            files = [(
+                "analysis_summary", (
+                    "detailed_summary.json",
+                    open(summary_file, "rb"),
+                    "application/json",
+                ),
+            )]
+
+        r = requests.post(uri, data=payload, files=files, headers=headers)
+
+        print(r.json())
+
+        if r.status_code != 200:
+            raise CleveError(
+                f"failed to add analysis for run {run_id}: "
+                f"HTTP {r.status_code} {r.json()}"
+            )
+
+    def update_analysis(self,
+                        run_id: str,
+                        analysis_id: str,
+                        state: Optional[str],
+                        summary_file: Optional[str]) -> None:
+        if self.key is None:
+            raise CleveError("no API key provided")
+
+        uri = f"{self.uri}/runs/{run_id}/analysis/{analysis_id}"
+        headers = {"Authorization": self.key}
+
+        payload = None
+        files = None
+
+        if state is not None:
+            payload = {
+                "state": state,
+            }
+
+        if summary_file is not None:
+            files = [(
+                "analysis_summary", (
+                    "detailed_summary.json",
+                    open(summary_file, "rb"),
+                    "application/json",
+                ),
+            )]
+
+        r = requests.patch(uri, data=payload, files=files, headers=headers)
+
+        print(r.json())
+
+        if r.status_code != 200:
+            raise CleveError(
+                f"failed to update analysis for run {run_id} in {self.uri}: "
+                f"HTTP {r.status_code} {r.json()}"
+            )
+
 
 class CleveMock(Cleve):
 

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -67,6 +67,28 @@ class Cleve:
                 f"HTTP {r.status_code} {r.json()}"
             )
 
+    def update_run(self,
+                   run_id: str,
+                   state: str) -> None:
+        if self.key is None:
+            raise CleveError("no API key provided")
+
+        uri = f"{self.uri}/runs/{run_id}"
+        headers = {"Authorization": self.key}
+        payload = {
+            "state": state,
+        }
+
+        r = requests.patch(uri, data=payload, headers=headers)
+
+        print(r.json())
+
+        if r.status_code != 200:
+            raise CleveError(
+                f"failed to update run {run_id} in {self.uri}: "
+                f"HTTP {r.status_code} {r.json()}"
+            )
+
 
 class CleveMock(Cleve):
 

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -16,13 +16,14 @@ class Cleve:
     def get_runs(self,
                  platform: Optional[str] = None,
                  state: Optional[str] = None) -> Dict[str, Dict]:
-        uri = f"{self.uri}/runs?brief"
-        if platform:
-            uri += f"&platform={platform}"
-        if state:
-            uri += f"&state={state}"
+        uri = f"{self.uri}/runs"
+        payload = {
+            "brief": True,
+            "platform": platform,
+            "state": state,
+        }
 
-        r = requests.get(uri)
+        r = requests.get(uri, data=payload)
 
         if r.status_code != 200:
             raise CleveError(

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -34,7 +34,10 @@ class Cleve:
             runs[run["run_id"]] = run
         return runs
 
-    def add_run(self, runparameters: str, path: str, state: str):
+    def add_run(self,
+                runparameters: str,
+                path: str,
+                state: str) -> Dict[str, Any]:
         if self.key is None:
             raise CleveError("no API key provided")
 
@@ -59,17 +62,17 @@ class Cleve:
             headers=headers
         )
 
-        print(r.json())
-
         if r.status_code != 200:
             raise CleveError(
                 f"failed to add run to {self.uri}: "
                 f"HTTP {r.status_code} {r.json()}"
             )
 
+        return r.json()
+
     def update_run(self,
                    run_id: str,
-                   state: str) -> None:
+                   state: str) -> Dict[str, Any]:
         if self.key is None:
             raise CleveError("no API key provided")
 
@@ -81,19 +84,19 @@ class Cleve:
 
         r = requests.patch(uri, data=payload, headers=headers)
 
-        print(r.json())
-
         if r.status_code != 200:
             raise CleveError(
                 f"failed to update run {run_id} in {self.uri}: "
                 f"HTTP {r.status_code} {r.json()}"
             )
 
+        return r.json()
+
     def add_analysis(self,
                      run_id: str,
                      path: str,
                      state: str,
-                     summary_file: Optional[str]) -> None:
+                     summary_file: Optional[str]) -> Dict[str, Any]:
         if self.key is None:
             raise CleveError("no API key provided")
 
@@ -116,19 +119,19 @@ class Cleve:
 
         r = requests.post(uri, files=files, headers=headers)
 
-        print(r.json())
-
         if r.status_code != 200:
             raise CleveError(
                 f"failed to add analysis for run {run_id}: "
                 f"HTTP {r.status_code} {r.json()}"
             )
 
+        return r.json()
+
     def update_analysis(self,
                         run_id: str,
                         analysis_id: str,
                         state: Optional[str],
-                        summary_file: Optional[str]) -> None:
+                        summary_file: Optional[str]) -> Dict[str, Any]:
         if self.key is None:
             raise CleveError("no API key provided")
 
@@ -154,13 +157,13 @@ class Cleve:
 
         r = requests.patch(uri, data=payload, files=files, headers=headers)
 
-        print(r.json())
-
         if r.status_code != 200:
             raise CleveError(
                 f"failed to update analysis for run {run_id} in {self.uri}: "
                 f"HTTP {r.status_code} {r.json()}"
             )
+
+        return r.json()
 
 
 class CleveMock(Cleve):

--- a/policies/add_analysis_policy.yaml
+++ b/policies/add_analysis_policy.yaml
@@ -1,0 +1,10 @@
+---
+name: add_analysis.retry
+description: Retry adding an analysis directory on error
+enabled: true
+resource_ref: gmc_norr_seqdata.add_analysis
+policy_type: action.retry
+parameters:
+  retry_on: failure
+  max_retry_count: 1
+  delay: 5

--- a/rules/add_analysis_dir.yaml
+++ b/rules/add_analysis_dir.yaml
@@ -1,0 +1,20 @@
+---
+name: add_analysis_directory
+pack: gmc_norr_seqdata
+enabled: true
+
+trigger:
+  type: gmc_norr_seqdata.new_directory
+
+criteria:
+  trigger.directory_type:
+    type: equals
+    pattern: analysis
+
+action:
+  ref: gmc_norr_seqdata.add_analysis
+  parameters:
+    run_id: "{{ trigger.run_id }}"
+    path: "{{ trigger.path }}"
+    state: "{{ trigger.state }}"
+    summary_file: "{{ trigger.summary_file }}"

--- a/rules/add_analysis_dir.yaml
+++ b/rules/add_analysis_dir.yaml
@@ -1,5 +1,6 @@
 ---
 name: add_analysis_directory
+description: Rule for adding an analysis directory to an exising NovaSeq run
 pack: gmc_norr_seqdata
 enabled: true
 

--- a/rules/add_analysis_dir.yaml
+++ b/rules/add_analysis_dir.yaml
@@ -17,4 +17,4 @@ action:
     run_id: "{{ trigger.run_id }}"
     path: "{{ trigger.path }}"
     state: "{{ trigger.state }}"
-    summary_file: "{{ trigger.summary_file }}"
+    summary_file: "{{ trigger.summary_file | use_none }}"

--- a/rules/add_rundir.yaml
+++ b/rules/add_rundir.yaml
@@ -1,5 +1,6 @@
 ---
 name: add_run_directory
+description: Rule for adding a new sequencing run directory
 pack: gmc_norr_seqdata
 enabled: true
 

--- a/rules/add_rundir.yaml
+++ b/rules/add_rundir.yaml
@@ -12,7 +12,7 @@ criteria:
     pattern: run
   trigger.state:
     type: inside
-    pattern: [new, ready, pending]
+    pattern: [new, ready, pending, complete]
 
 action:
   ref: gmc_norr_seqdata.add_run

--- a/rules/add_rundir.yaml
+++ b/rules/add_rundir.yaml
@@ -1,0 +1,22 @@
+---
+name: add_run_directory
+pack: gmc_norr_seqdata
+enabled: true
+
+trigger:
+  type: gmc_norr_seqdata.new_directory
+
+criteria:
+  trigger.directory_type:
+    type: equals
+    pattern: run
+  trigger.state:
+    type: inside
+    pattern: [new, ready, pending]
+
+action:
+  ref: gmc_norr_seqdata.add_run
+  parameters:
+    runparameters: "{{ trigger.runparameters }}"
+    path: "{{ trigger.path }}"
+    state: "{{ trigger.state }}"

--- a/rules/notify_incomplete_run.yaml
+++ b/rules/notify_incomplete_run.yaml
@@ -15,11 +15,12 @@ criteria:
 action:
   ref: email.send_email
   parameters:
+    account: SMTP-VLL
     email_from: Stackstorm
-    email_to: "niklas.mahler@regionvasterbotten.se"
+    email_to: ["niklas.mahler@regionvasterbotten.se"]
     subject: Incomplete sequencing run
-    body: |
-      A sequencing run directory is not complete and cannot be added to the database.
+    message: |
+      A sequencing run directory is incomplete and cannot be added to the database.
 
       Path: {{ trigger.path }}
       State: {{ trigger.state }}

--- a/rules/notify_incomplete_run.yaml
+++ b/rules/notify_incomplete_run.yaml
@@ -1,0 +1,25 @@
+---
+name: notify_incomplete_run
+pack: gmc_norr_seqdata
+enabled: true
+
+trigger:
+  type: gmc_norr_seqdata.incomplete_directory
+
+criteria:
+  trigger.directory_type:
+    type: equals
+    pattern: run
+
+action:
+  ref: email.send_email
+  parameters:
+    email_from: Stackstorm
+    email_to: "niklas.mahler@regionvasterbotten.se"
+    subject: Incomplete sequencing run
+    body: |
+      A sequencing run directory is not complete and cannot be added to the database.
+
+      Path: {{ trigger.path }}
+      State: {{ trigger.state }}
+      Message: {{ trigger.message }}

--- a/rules/notify_incomplete_run.yaml
+++ b/rules/notify_incomplete_run.yaml
@@ -17,7 +17,7 @@ action:
   parameters:
     account: SMTP-VLL
     email_from: Stackstorm
-    email_to: ["niklas.mahler@regionvasterbotten.se"]
+    email_to: "{{ trigger.email | to_json_string }}"
     subject: Incomplete sequencing run
     message: |
       A sequencing run directory is incomplete and cannot be added to the database.

--- a/rules/notify_incomplete_run.yaml
+++ b/rules/notify_incomplete_run.yaml
@@ -16,7 +16,7 @@ action:
   ref: email.send_email
   parameters:
     account: SMTP-VLL
-    email_from: Stackstorm
+    email_from: stackstorm@regionvasterbotten.se
     email_to: "{{ trigger.email | to_json_string }}"
     subject: Incomplete sequencing run
     message: |

--- a/rules/notify_incomplete_run.yaml
+++ b/rules/notify_incomplete_run.yaml
@@ -1,5 +1,6 @@
 ---
 name: notify_incomplete_run
+description: Rule for sending an email when an incomplete run directory is found
 pack: gmc_norr_seqdata
 enabled: true
 

--- a/rules/update_analysis.yaml
+++ b/rules/update_analysis.yaml
@@ -1,0 +1,20 @@
+---
+name: update_analysis
+pack: gmc_norr_seqdata
+enabled: true
+
+trigger:
+  type: gmc_norr_seqdata.state_change
+
+criteria:
+  trigger.directory_type:
+    type: equals
+    pattern: analysis
+
+action:
+  ref: gmc_norr_seqdata.update_analysis
+  parameters:
+    run_id: "{{ trigger.run_id }}"
+    path: "{{ trigger.path }}"
+    state: "{{ trigger.state }}"
+    summary_file: "{{ trigger.summary_file }}"

--- a/rules/update_analysis.yaml
+++ b/rules/update_analysis.yaml
@@ -1,5 +1,6 @@
 ---
 name: update_analysis
+description: Rule for updating the state and summary for an existing analysis
 pack: gmc_norr_seqdata
 enabled: true
 
@@ -17,4 +18,4 @@ action:
     run_id: "{{ trigger.run_id }}"
     path: "{{ trigger.path }}"
     state: "{{ trigger.state }}"
-    summary_file: "{{ trigger.summary_file }}"
+    summary_file: "{{ trigger.summary_file | use_none }}"

--- a/rules/update_run_state.yaml
+++ b/rules/update_run_state.yaml
@@ -1,5 +1,6 @@
 ---
 name: update_run_state
+description: Rule for updating the state of an existing sequencing run
 pack: gmc_norr_seqdata
 enabled: true
 

--- a/rules/update_run_state.yaml
+++ b/rules/update_run_state.yaml
@@ -1,0 +1,18 @@
+---
+name: update_run_state
+pack: gmc_norr_seqdata
+enabled: true
+
+trigger:
+  type: gmc_norr_seqdata.state_change
+
+criteria:
+  trigger.directory_type:
+    type: equals
+    pattern: run
+
+action:
+  ref: gmc_norr_seqdata.update_run_state
+  parameters:
+    run_id: "{{ trigger.run_id }}"
+    state: "{{ trigger.state }}"

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -110,7 +110,6 @@ class IlluminaDirectorySensor(PollingSensor):
                     self._logger.debug(f"incomplete run directory: {str(e)}")
                     self._emit_trigger(
                         "incomplete_directory",
-                        run_id=None,
                         path=str(dirpath),
                         state=DirectoryState.INCOMPLETE,
                         directory_type=DirectoryType.RUN,
@@ -121,7 +120,6 @@ class IlluminaDirectorySensor(PollingSensor):
                     self._logger.debug(f"error parsing RunParameters.xml: {dirpath}")
                     self._emit_trigger(
                         "incomplete_directory",
-                        run_id=None,
                         path=str(dirpath),
                         state=DirectoryState.ERROR,
                         directory_type=DirectoryType.RUN,

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -205,10 +205,12 @@ class IlluminaDirectorySensor(PollingSensor):
             if len(detailed_summary) == 0:
                 detailed_summary = None
             else:
-                detailed_summary = detailed_summary[0]
+                detailed_summary = str(detailed_summary[0])
                 self._logger.debug(
                     f"found detailed summary at {detailed_summary}"
                 )
+
+            analysis_id = dirpath.name
 
             if str(dirpath) in analyses:
                 self._logger.debug(
@@ -223,8 +225,8 @@ class IlluminaDirectorySensor(PollingSensor):
                     self._emit_trigger(
                         "state_change",
                         run_id=run_id,
-                        path=str(dirpath),
-                        summary_file=str(detailed_summary) if detailed_summary else None,
+                        analysis_id=analysis_id,
+                        summary_file=detailed_summary,
                         state=current_state,
                         directory_type=DirectoryType.ANALYSIS)
             else:
@@ -232,7 +234,7 @@ class IlluminaDirectorySensor(PollingSensor):
                 self._emit_trigger(
                     "new_directory",
                     run_id=run_id,
-                    summary_file=str(detailed_summary) if detailed_summary else None,
+                    summary_file=detailed_summary,
                     path=str(dirpath),
                     state=self.analysis_directory_state(dirpath),
                     directory_type=DirectoryType.ANALYSIS)

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -109,11 +109,17 @@ class IlluminaDirectorySensor(PollingSensor):
                                      message: str = "") -> None:
         self._logger.debug(f"incomplete run directory: {rundir}")
         self._logger.debug(f"reason: {message}")
+        email = self.config.get("notification_email", [])
+        if not email:
+            self._logger.info("no email addresses provided, "
+                              "no trigger dispatched")
+            return
         payload = dict(
             path=str(rundir),
             state=DirectoryState.INCOMPLETE,
             directory_type=DirectoryType.RUN,
             message=message,
+            email=self.config.get("notification_email", []),
         )
         t = self._find_incomplete_directory_trigger(payload)
         if t is None:

--- a/sensors/illumina_directory_sensor.yaml
+++ b/sensors/illumina_directory_sensor.yaml
@@ -106,6 +106,13 @@ trigger_types:
           type: string
           description: The path to the directory
           required: true
+        email:
+          type: array
+          description: An array of email addresses to send notifications to
+          required: true
+          default: []
+          items:
+            type: string
         state:
           type: string
           description: The state of the directory

--- a/sensors/illumina_directory_sensor.yaml
+++ b/sensors/illumina_directory_sensor.yaml
@@ -19,6 +19,12 @@ trigger_types:
           type: string
           description: The ID of the run
           required: true
+        analysis_id:
+          type: string
+          description: >
+            The ID of the analysis. Required if the state change is
+            associated with an analysis directory.
+          required: false
         path:
           type: string
           description: The directory whose state has changed

--- a/sensors/illumina_directory_sensor.yaml
+++ b/sensors/illumina_directory_sensor.yaml
@@ -18,19 +18,30 @@ trigger_types:
         run_id:
           type: string
           description: The ID of the run
+          required: true
         path:
           type: string
           description: The directory whose state has changed
+          required: true
+        summary_file:
+          type: string
+          description: >
+            Path to the detailed summary JSON for analysis directories. Needed
+            in order to fully update analysis info.
+          required: false
         state:
           type: string
           description: The state of the directory
+          required: true
         directory_type:
           type: string
           description: The type of directory
           enum: [run, analysis]
+          required: true
         message:
           type: string
           description: A message associated with the state change
+          required: false
 
   - name: new_directory
     pack: gmc_norr_seqdata
@@ -42,19 +53,35 @@ trigger_types:
         run_id:
           type: string
           description: The ID of the run
+          required: true
+        runparameters:
+          type: string
+          description: >
+            Path to the runparameters file. Needed for run directories.
+          required: false
+        summary_file:
+          type: string
+          description: >
+            Path to the detailed summary JSON for analysis directories. Needed
+            in order to fully add analysis info.
+          required: false
         path:
           type: string
           description: The path to the new directory
+          required: true
         state:
           type: string
           description: The state of the directory
+          required: true
         directory_type:
           type: string
           description: The type of directory
           enum: [run, analysis]
+          required: true
         message:
           type: string
           description: A message associated with the state change
+          required: false
 
   - name: incomplete_directory
     pack: gmc_norr_seqdata
@@ -68,17 +95,22 @@ trigger_types:
           type: string
           description: The ID of the run, which cannot be determined if it is incomplete
           const: null
+          required: false
         path:
           type: string
           description: The path to the directory
+          required: true
         state:
           type: string
           description: The state of the directory
           enum: [incomplete, error]
+          required: true
         directory_type:
           type: string
           description: The type of directory
           enum: [run, analysis]
+          required: true
         message:
           type: string
           description: A message describing why the directory is incomplete
+          required: false

--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -70,7 +70,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": None,
                 "path": str(run_dirs[0]),
                 "state": DirectoryState.INCOMPLETE,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
 
@@ -84,7 +84,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": None,
                 "path": str(run_dirs[0]),
                 "state": DirectoryState.ERROR,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
 
@@ -99,7 +99,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(run_dirs[0]),
                 "state": DirectoryState.PENDING,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
 
@@ -121,7 +121,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(run_dirs[0]),
                 "state": DirectoryState.READY,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
 
@@ -144,7 +144,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(Path(self.watch_directories[0].name) / "run1"),
                 "state": DirectoryState.MOVED,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
 
@@ -171,7 +171,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(Path(self.watch_directories[0].name) / "run1_moved"),
                 "state": DirectoryState.MOVED,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
 
@@ -197,7 +197,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(Path(self.watch_directories[0].name) / "run1_moved"),
                 "state": DirectoryState.MOVED,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
         self.assertTriggerDispatched(
@@ -206,7 +206,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(Path(self.watch_directories[0].name) / "run1_moved"),
                 "state": DirectoryState.READY,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
 
@@ -228,7 +228,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(run_directory),
                 "state": DirectoryState.READY,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
         self.assertTriggerDispatched(
@@ -237,7 +237,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(analysis_directory),
                 "state": DirectoryState.PENDING,
-                "type": DirectoryType.ANALYSIS,
+                "directory_type": DirectoryType.ANALYSIS,
             }
         )
 
@@ -275,7 +275,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(analysis_directory),
                 "state": DirectoryState.READY,
-                "type": DirectoryType.ANALYSIS,
+                "directory_type": DirectoryType.ANALYSIS,
             }
         )
 
@@ -296,7 +296,7 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(run_directory),
                 "state": DirectoryState.READY,
-                "type": DirectoryType.RUN,
+                "directory_type": DirectoryType.RUN,
             }
         )
 
@@ -306,6 +306,6 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "run_id": "run1",
                 "path": str(analysis_directory),
                 "state": DirectoryState.PENDING,
-                "type": DirectoryType.ANALYSIS,
+                "directory_type": DirectoryType.ANALYSIS,
             }
         )


### PR DESCRIPTION
This PR adds rules and actions for some basic handling of sequencing runs. It now has rules for adding runs to the database, adding analysis directories to runs, update the state of runs and analyses, as well as sending notifications if something is not working as it should.