### PR TITLE
fix: add brief flag when fetching runs

### DIFF
--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -78,12 +78,14 @@ class Cleve:
             raise CleveError("no API key provided")
 
         uri = f"{self.uri}/runs/{run_id}"
-        headers = {"Authorization": self.key}
+        headers = {
+            "Authorization": self.key,
+        }
         payload = {
             "state": state,
         }
 
-        r = requests.patch(uri, data=payload, headers=headers)
+        r = requests.patch(uri, json=payload, headers=headers)
 
         if r.status_code != 200:
             raise CleveError(

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -28,7 +28,7 @@ class Cleve:
 
         if r.status_code != 200:
             raise CleveError(
-                f"failed to fetch runs from {self.uri}: HTTP {r.status_code}")
+                f"failed to fetch runs from {uri}: HTTP {r.status_code}")
 
         runs = {}
         for run in r.json():
@@ -65,7 +65,7 @@ class Cleve:
 
         if r.status_code != 200:
             raise CleveError(
-                f"failed to add run to {self.uri}: "
+                f"failed to add run to {uri}: "
                 f"HTTP {r.status_code} {r.json()}"
             )
 
@@ -89,7 +89,7 @@ class Cleve:
 
         if r.status_code != 200:
             raise CleveError(
-                f"failed to update run {run_id} in {self.uri}: "
+                f"failed to update run {run_id} in {uri}: "
                 f"HTTP {r.status_code} {r.json()}"
             )
 
@@ -162,7 +162,7 @@ class Cleve:
 
         if r.status_code != 200:
             raise CleveError(
-                f"failed to update analysis for run {run_id} in {self.uri}: "
+                f"failed to update analysis for run {run_id} in {uri}: "
                 f"HTTP {r.status_code} {r.json()}"
             )
 

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -14,11 +14,12 @@ class Cleve:
         self.key = key
 
     def get_runs(self,
+                 brief=True,
                  platform: Optional[str] = None,
                  state: Optional[str] = None) -> Dict[str, Dict]:
         uri = f"{self.uri}/runs"
         payload = {
-            "brief": True,
+            "brief": brief,
             "platform": platform,
             "state": state,
         }

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -72,10 +72,10 @@ class IlluminaDirectorySensor(PollingSensor):
         Poll the file system for new run and analysis directories
         as well as state changes of existing directories.
         """
-        registered_rundirs = self.cleve.get_runs()
+        registered_rundirs = self.cleve.get_runs(brief=True)
         self._check_for_run(registered_rundirs)
 
-        runs = self.cleve.get_runs(platform="NovaSeq", state="ready")
+        runs = self.cleve.get_runs(brief=False, platform="NovaSeq", state="ready")
         self._logger.debug(f"found {len(runs)} ready NovaSeq runs")
         for run_id, run in runs.items():
             self._check_for_analysis(


### PR DESCRIPTION
Some times when fetching the runs we need more information, so setting brief by default was a bit limiting. This makes the cleve service accept a brief flag when fetching runs.

In addition, the URL in the exceptions has been corrected, and the content type when updating runs has also been fixed.