### PR TITLE
fix: catch ValueErrors when extracting run ID

### DIFF
--- a/rules/notify_incomplete_run.yaml
+++ b/rules/notify_incomplete_run.yaml
@@ -2,7 +2,7 @@
 name: notify_incomplete_run
 description: Rule for sending an email when an incomplete run directory is found
 pack: gmc_norr_seqdata
-enabled: true
+enabled: false
 
 trigger:
   type: gmc_norr_seqdata.incomplete_directory

--- a/rules/notify_incomplete_run.yaml
+++ b/rules/notify_incomplete_run.yaml
@@ -2,7 +2,7 @@
 name: notify_incomplete_run
 description: Rule for sending an email when an incomplete run directory is found
 pack: gmc_norr_seqdata
-enabled: false
+enabled: true
 
 trigger:
   type: gmc_norr_seqdata.incomplete_directory

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -174,6 +174,13 @@ class IlluminaDirectorySensor(PollingSensor):
                         str(e),
                     )
                     continue
+                except ValueError as e:
+                    self._handle_incomplete_directory(
+                        dirpath,
+                        DirectoryState.ERROR,
+                        str(e),
+                    )
+                    continue
                 self._logger.debug(f"identified run as {run_id}")
                 if run_id in registered_rundirs:
                     registered_path = registered_rundirs[run_id]["path"]

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -320,6 +320,8 @@ class IlluminaDirectorySensor(PollingSensor):
 
         :param path: The path to the sequencing run directory
         :type path: pathlib.Path
+        :raises IOError: If the RunParameters.xml file cannot be found
+        :raises ET.ParseError: If the RunParameters.xml file cannot be parsed
         :raises ValueError: If the sequencing platform or run ID cannot be identified
         :return: The run ID.
         :rtype: str

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -350,7 +350,7 @@ class IlluminaDirectorySensor(PollingSensor):
 
         self._logger.debug(f"platform is {platform}")
 
-        run_id = root.find("RunId")
+        run_id = root.find("RunId") or root.find("RunID")
         if run_id is None:
             raise ValueError(f"RunId not found in {runparamsfile}")
         return str(run_id.text)

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -16,7 +16,7 @@ PLATFORMS = {
         "ready_marker": "CopyComplete.txt",
     },
     "NextSeq": {
-        "serial_tag": "InstrumentId",
+        "serial_tag": "InstrumentID",
         "serial_pattern": "NB",
         "ready_marker": "CopyComplete.txt",
     },


### PR DESCRIPTION
ValueErrors weren't being handled when extracting the run IDs, causing the sensor to crash. Now these instead result in the incomplete_directory being triggered instead, which is the correct way to handle this.

While looking at this, some other issues were also found related to how NextSeq runs were identified. These issues have now been addressed.