### PR TITLE
fix: run IDs not extracted properly

### DIFF
--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -350,8 +350,11 @@ class IlluminaDirectorySensor(PollingSensor):
 
         self._logger.debug(f"platform is {platform}")
 
-        run_id = root.find("RunId") or root.find("RunID")
-        if run_id is None:
+        for x in ("RunID", "RunId"):
+            run_id = root.find(x)
+            if run_id is not None:
+                break
+        else:
             raise ValueError(f"RunId not found in {runparamsfile}")
         return str(run_id.text)
 


### PR DESCRIPTION
For some reason, the or assignment that I was using is not working as expected in this case. I instead resorted to a loop over the possible tags that might be used.