### PR TITLE
test: better mocking of the cleve service

### DIFF
--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -1,5 +1,4 @@
 import requests
-import time
 from typing import Any, Dict, Optional
 
 
@@ -9,7 +8,11 @@ class CleveError(Exception):
 
 class Cleve:
 
-    def __init__(self, host: str, port: int, key: Optional[str] = None):
+    def __init__(
+            self,
+            host: str = "localhost",
+            port: int = 8080,
+            key: Optional[str] = None):
         self.uri = f"http://{host}:{port}/api"
         self.key = key
 
@@ -167,47 +170,3 @@ class Cleve:
             )
 
         return r.json()
-
-
-class CleveMock(Cleve):
-
-    def __init__(self, runs: Optional[Dict[str, Dict]] = None):
-        self.key = "supersecretapikey"
-        self.runs = {}
-        if runs is not None:
-            self.runs = runs
-
-    def get_runs(self, platform: Optional[str] = None, state: Optional[str] = None) -> Dict[str, Dict]:
-        runs = {}
-        for run_id, run in self.runs.items():
-            last_state = sorted(
-                run["state_history"], key=lambda x: x["time"], reverse=True)[0]["state"]
-            if platform and run["platform"] != platform:
-                continue
-            if state and last_state != state:
-                continue
-            runs[run_id] = run
-        return runs
-
-    def add_run(self, key: str, run: Dict):
-        if key != self.key:
-            raise CleveError("invalid API key")
-        if "run_id" not in run:
-            raise CleveError("run must have a run_id")
-        if "state_history" not in run:
-            raise CleveError("run must have a state_history")
-        if "platform" not in run:
-            raise CleveError("run must have a platform")
-        self.runs[run["run_id"]] = run
-
-    def update_run(self, key: str, run_id: str, state: Optional[str] = None, analysis: Optional[Dict] = None):
-        if key != self.key:
-            raise CleveError("invalid API key")
-        if run_id not in self.runs:
-            raise CleveError(f"run {run_id} not found")
-
-        if state is not None:
-            self.runs[run_id]["state_history"].append(
-                {"state": state, "time": time.time()})
-        if analysis is not None:
-            self.runs[run_id]["analysis"].append(analysis)

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -218,6 +218,10 @@ class IlluminaDirectorySensor(PollingSensor):
 
         # Check if existing runs have been moved out of the watched directories
         for run in registered_rundirs.values():
+            # Don't emit a trigger if the state already is moved
+            state = run["state_history"][0]["state"]
+            if state == DirectoryState.MOVED:
+                continue
             dirpath = Path(run["path"])
             if run["run_id"] not in moved_dirs and not dirpath.is_dir():
                 self._logger.debug(f"run {run['run_id']} is missing")

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -194,7 +194,10 @@ class IlluminaDirectorySensor(PollingSensor):
                             state=DirectoryState.MOVED,
                             directory_type=DirectoryType.RUN)
 
-                    registered_state = registered_rundirs[run_id]["state_history"][0]["state"]
+                    state_history = registered_rundirs[run_id].get("state_history", [])
+                    registered_state = None
+                    if state_history:
+                        registered_state = state_history[0]["state"]
                     current_state = self.run_directory_state(dirpath)
 
                     if registered_state != current_state:
@@ -219,8 +222,8 @@ class IlluminaDirectorySensor(PollingSensor):
         # Check if existing runs have been moved out of the watched directories
         for run in registered_rundirs.values():
             # Don't emit a trigger if the state already is moved
-            state = run["state_history"][0]["state"]
-            if state == DirectoryState.MOVED:
+            state_history = run.get("state_history", [])
+            if state_history and state_history[0]["state"] == DirectoryState.MOVED:
                 continue
             dirpath = Path(run["path"])
             if run["run_id"] not in moved_dirs and not dirpath.is_dir():

--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -29,6 +29,9 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.cleve.add_run = Mock(
             side_effect=self._add_run
         )
+        self.cleve.update_run = Mock(
+            side_effect=self._update_run
+        )
         self.cleve.add_analysis = Mock(
             side_effect=self._add_analysis
         )
@@ -62,6 +65,12 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
 
     def _add_run(self, run_id: str, run: Dict[str, Any]):
         self.cleve.runs[run_id] = run
+
+    def _update_run(self, run_id: str, state: str):
+        self.cleve.runs[run_id]["state_history"].insert(0, {
+            "state": state,
+            "time": time.time(),
+        })
 
     def _add_analysis(self, run_id: str, analysis: Dict[str, Any]):
         self.cleve.runs[run_id]["analysis"].append(analysis)
@@ -205,6 +214,9 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "directory_type": DirectoryType.RUN,
             }
         )
+
+        # Update the run state
+        self.cleve.update_run("run1", state=DirectoryState.MOVED)
 
         # Move should not be issued again for the same run
         self.sensor.poll()


### PR DESCRIPTION
This PR moves the responsibility of mocking the cleve service to the tests themselves. This eliminates the need for a dedicated mock class, and makes testing more flexible.

In addition to this, I also fixed a couple of issues regarding to state changes. One issue was that if a directory had been moved, a state change would be emitted on every poll. Now it will not update the state if it has already been registered as moved.

Another issue was that if the state history for some reason would be empty, the sensor would crash. This is now checked for.

For both these cases tests were added.