### PR TITLE
feat: supply run info when adding a new run

### DIFF
--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -53,6 +53,12 @@ class Cleve:
                 open(runparameters, "rb"),
                 "application/xml",
             ),
+        ), (
+            "runinfo", (
+                "RunInfo.xml",
+                open(path, "rb"),
+                "application/xml",
+            ),
         )]
         payload = {
             "path": path,

--- a/rules/add_rundir.yaml
+++ b/rules/add_rundir.yaml
@@ -19,5 +19,6 @@ action:
   ref: gmc_norr_seqdata.add_run
   parameters:
     runparameters: "{{ trigger.runparameters }}"
+    runinfo: "{{ trigger.runinfo }}"
     path: "{{ trigger.path }}"
     state: "{{ trigger.state }}"

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -216,6 +216,7 @@ class IlluminaDirectorySensor(PollingSensor):
                         "new_directory",
                         run_id=run_id,
                         runparameters=str(dirpath / "RunParameters.xml"),
+                        runinfo=str(dirpath / "RunInfo.xml"),
                         path=str(dirpath),
                         state=self.run_directory_state(dirpath),
                         directory_type=DirectoryType.RUN)

--- a/sensors/illumina_directory_sensor.yaml
+++ b/sensors/illumina_directory_sensor.yaml
@@ -65,6 +65,11 @@ trigger_types:
           description: >
             Path to the runparameters file. Needed for run directories.
           required: false
+        runinfo:
+          type: string
+          description: >
+            Path to the runinfo file. Needed for run directories.
+          required: false
         summary_file:
           type: string
           description: >


### PR DESCRIPTION
The backend has been updated so the runs should also include information from `RunInfo.xml`. This PR reflects this update. If the file cannot be found, an incomplete directory trigger with a pending state will be emitted. If the file is empty, an incomplete directory trigger with an error state will be emitted.