### PR TITLE
fix: add run action issues

### DIFF
--- a/actions/add_run.py
+++ b/actions/add_run.py
@@ -14,11 +14,13 @@ class AddRunAction(Action):
         )
 
     def run(self,
-            runparameters: str,
             path: str,
-            state: str) -> Dict[str, Any]:
+            state: str,
+            runparameters: str,
+            runinfo: str) -> Dict[str, Any]:
         return self.cleve.add_run(
             runparameters=runparameters,
+            runinfo=runinfo,
             path=path,
             state=state,
         )

--- a/actions/add_run.yaml
+++ b/actions/add_run.yaml
@@ -21,3 +21,8 @@ parameters:
     description: Path to the runparameters file
     required: true
     position: 2
+  runinfo:
+    type: string
+    description: Path to the runinfo file
+    required: true
+    position: 3

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -40,6 +40,7 @@ class Cleve:
 
     def add_run(self,
                 runparameters: str,
+                runinfo: str,
                 path: str,
                 state: str) -> Dict[str, Any]:
         if self.key is None:
@@ -56,7 +57,7 @@ class Cleve:
         ), (
             "runinfo", (
                 "RunInfo.xml",
-                open(path, "rb"),
+                open(runinfo, "rb"),
                 "application/xml",
             ),
         )]

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -22,10 +22,15 @@ class Cleve:
                  state: Optional[str] = None) -> Dict[str, Dict]:
         uri = f"{self.uri}/runs"
         payload = {
-            "brief": brief,
             "platform": platform,
             "state": state,
         }
+
+        # Must exclude brief if false since the response
+        # would otherwise always be brief if the key is
+        # present in the url.
+        if brief:
+            payload["brief"] = "yes"
 
         r = requests.get(uri, params=payload)
 

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -289,6 +289,12 @@ class IlluminaDirectorySensor(PollingSensor):
 
         for analysis_dir in analysis_dirs:
             dirpath = Path(root) / str(analysis_dir)
+            analysis_id = dirpath.name
+
+            if not analysis_id.isdigit():
+                # Most likely not a real analysis directory, ignore it
+                continue
+
             self._logger.debug(f"looking at analysis at {dirpath}")
             detailed_summary = list((dirpath / "Data" / "summary")
                                     .glob("*/detailed_summary.json"))
@@ -300,8 +306,6 @@ class IlluminaDirectorySensor(PollingSensor):
                 self._logger.debug(
                     f"found detailed summary at {detailed_summary}"
                 )
-
-            analysis_id = dirpath.name
 
             if str(dirpath) in analyses:
                 self._logger.debug(

--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -430,6 +430,10 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
             },
         )
 
+        # Should not find anything to update
+        self.sensor.poll()
+        self.assertEqual(len(self.get_dispatched_triggers()), 2)
+
         (analysis_directory / "CopyComplete.txt").touch()
 
         self.sensor.poll()

--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -386,7 +386,10 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         analysis_directory = run_directory / "Analysis" / "1"
         analysis_directory.mkdir(parents=True)
 
-        # Should find a new run directory and a new analysis directory
+        not_analysis_directory = run_directory / "Analysis" / "tmp"
+        not_analysis_directory.mkdir(parents=True)
+
+        # Should find a new run directory and a (1) new analysis directory
         self.sensor.poll()
         self.assertEqual(len(self.get_dispatched_triggers()), 2)
         self.assertTriggerDispatched(


### PR DESCRIPTION
Firstly, the run info file wasn't passed properly to the `add_run` action, so this was fixed. Furthermore, the request for getting all the runs had a bug which resulted in the response always returning the brief result, i.e. without the analysis object for each run. This resulted in analyses wrongly being detected as new, and it then errored out when trying to already add an existing run. This has also been addressed.

I also restricted the analysis directory names to integers, which is what is currently being output by the machine. This is something we have to keep in mind for the future in case this changes, either from the supplier or by the means of configuration.