### PR TITLE
feat: rule and action for adding run qc

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ ref | description
 --- | ---
 add_analysis     | Add an analysis associated with a sequencing run
 add_run          | Add a sequencing run to the database
+add_run_qc       | Add sequencing QC data to the database
 update_analysis  | Update an analysis associated with a NovaSeq sequencing run
 update_run_state | Update the state of a run
 
@@ -42,6 +43,7 @@ ref | description
 --- | ---
 add_analysis_directory | Rule for adding an analysis directory to an exising NovaSeq run
 add_run_directory      | Rule for adding a new sequencing run directory
+add_run_qc             | Rule for adding QC data to a sequencing run
 notify_incomplete      | Rule for sending an email when an incomplete run directory is found
 update_analysis        | Rule for updating the state and summary for an existing analysis
 update_run_state       | Rule for updating the state of an existing sequencing run

--- a/actions/add_run_qc.py
+++ b/actions/add_run_qc.py
@@ -1,0 +1,20 @@
+import cleve_service
+from st2common.runners.base_action import Action
+from typing import Any, Dict
+
+
+class AddRunQcAction(Action):
+
+    def __init__(self, config, action_service):
+        super().__init__(config, action_service)
+        if "cleve_service" in self.config:
+            self.cleve = self.config.get("cleve_service")
+        else:
+            self.cleve = cleve_service.Cleve(
+                config.get("cleve").get("host"),
+                config.get("cleve").get("port"),
+                config.get("cleve").get("api_key"),
+            )
+
+    def run(self, run_id: str) -> Dict[str, Any]:
+        return self.cleve.add_run_qc(run_id=run_id)

--- a/actions/add_run_qc.py
+++ b/actions/add_run_qc.py
@@ -1,5 +1,6 @@
 import cleve_service
 from st2common.runners.base_action import Action
+import sys
 from typing import Any, Dict
 
 
@@ -17,4 +18,8 @@ class AddRunQcAction(Action):
             )
 
     def run(self, run_id: str) -> Dict[str, Any]:
-        return self.cleve.add_run_qc(run_id=run_id)
+        try:
+            return self.cleve.add_run_qc(run_id=run_id)
+        except cleve_service.CleveError as e:
+            self.logger.error(e)
+            sys.exit(1)

--- a/actions/add_run_qc.yaml
+++ b/actions/add_run_qc.yaml
@@ -1,0 +1,13 @@
+---
+name: add_run_qc
+runner_type: python-script
+description: Add sequencing QC data to the database
+enabled: true
+entry_point: add_run_qc.py
+
+parameters:
+  run_id:
+    type: string
+    description: The ID of the run to add QC data for
+    required: true
+    position: 0

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -110,6 +110,25 @@ class Cleve:
 
         return r.json()
 
+    def add_run_qc(self, run_id: str) -> Dict[str, Any]:
+        if self.key is None:
+            raise CleveError("no API key provided")
+
+        uri = f"{self.uri}/runs/{run_id}/qc"
+        headers = {
+            "Authorization": self.key,
+        }
+
+        r = requests.post(uri, headers=headers)
+
+        if r.status_code != 200:
+            raise CleveError(
+                f"failed to add QC for run {run_id}: "
+                f"HTTP {r.status_code} {r.json()}"
+            )
+
+        return r.json()
+
     def add_analysis(self,
                      run_id: str,
                      path: str,

--- a/rules/add_run_qc.yaml
+++ b/rules/add_run_qc.yaml
@@ -1,0 +1,21 @@
+---
+name: add_run_qc
+description: Rule for adding QC data to a sequencing run
+pack: gmc_norr_seqdata
+enabled: true
+
+trigger:
+  type: gmc_norr_seqdata.state_change
+
+criteria:
+  trigger.directory_type:
+    type: equals
+    pattern: run
+  trigger.state:
+    type: equals
+    pattern: ready
+
+action:
+  ref: gmc_norr_seqdata.add_run_qc
+  parameters:
+    run_id: "{{ trigger.run_id }}"


### PR DESCRIPTION
This PR adds:

- A new method to the cleve service for adding QC data for a sequencing run.
- An action for adding QC data.
- A rule that triggers said action when a ready state is detected for a run directory.