### PR TITLE
fix: conform add_run to API changes

### DIFF
--- a/actions/add_run.py
+++ b/actions/add_run.py
@@ -7,20 +7,19 @@ class AddRunAction(Action):
 
     def __init__(self, config, action_service):
         super().__init__(config, action_service)
-        self.cleve = cleve_service.Cleve(
-            config.get("cleve").get("host"),
-            config.get("cleve").get("port"),
-            config.get("cleve").get("api_key"),
-        )
+        if "cleve_service" in self.config:
+            self.cleve = self.config.get("cleve_service")
+        else:
+            self.cleve = cleve_service.Cleve(
+                config.get("cleve").get("host"),
+                config.get("cleve").get("port"),
+                config.get("cleve").get("api_key"),
+            )
 
     def run(self,
             path: str,
-            state: str,
-            runparameters: str,
-            runinfo: str) -> Dict[str, Any]:
+            state: str) -> Dict[str, Any]:
         return self.cleve.add_run(
-            runparameters=runparameters,
-            runinfo=runinfo,
             path=path,
             state=state,
         )

--- a/actions/add_run.yaml
+++ b/actions/add_run.yaml
@@ -16,13 +16,3 @@ parameters:
     description: The detected state of the directory
     required: true
     position: 1
-  runparameters:
-    type: string
-    description: Path to the runparameters file
-    required: true
-    position: 2
-  runinfo:
-    type: string
-    description: Path to the runinfo file
-    required: true
-    position: 3

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -49,8 +49,6 @@ class Cleve:
         return runs
 
     def add_run(self,
-                runparameters: str,
-                runinfo: str,
                 path: str,
                 state: str) -> Dict[str, Any]:
         if self.key is None:
@@ -58,19 +56,6 @@ class Cleve:
 
         uri = f"{self.uri}/runs"
         headers = {"Authorization": self.key}
-        files = [(
-            "runparameters", (
-                "RunParameters.xml",
-                open(runparameters, "rb"),
-                "application/xml",
-            ),
-        ), (
-            "runinfo", (
-                "RunInfo.xml",
-                open(runinfo, "rb"),
-                "application/xml",
-            ),
-        )]
         payload = {
             "path": path,
             "state": state,
@@ -78,8 +63,7 @@ class Cleve:
 
         r = requests.post(
             uri,
-            files=files,
-            data=payload,
+            json=payload,
             headers=headers
         )
 

--- a/rules/add_rundir.yaml
+++ b/rules/add_rundir.yaml
@@ -18,7 +18,5 @@ criteria:
 action:
   ref: gmc_norr_seqdata.add_run
   parameters:
-    runparameters: "{{ trigger.runparameters }}"
-    runinfo: "{{ trigger.runinfo }}"
     path: "{{ trigger.path }}"
     state: "{{ trigger.state }}"

--- a/tests/test_action_add_run.py
+++ b/tests/test_action_add_run.py
@@ -1,0 +1,46 @@
+import requests
+from unittest.mock import Mock
+
+import cleve_service
+from st2tests.base import BaseActionTestCase
+
+from actions.add_run import AddRunAction
+
+
+def mock_post(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+    return MockResponse({"message": "run added"}, 200)
+
+
+class AddRunTestCase(BaseActionTestCase):
+    action_cls = AddRunAction
+
+    def setUp(self):
+        super(AddRunTestCase, self).setUp()
+
+        self.cleve = cleve_service.Cleve(key="secret")
+        self.action = self.get_action_instance(config={
+            "cleve_service": self.cleve
+        })
+
+    def test_add_run(self):
+        cleve_service.requests.post = Mock(side_effect=mock_post)
+        self.action.run(path="/path/to/run", state="ready")
+
+        cleve_service.requests.post.assert_called_with(
+            "http://localhost:8080/api/runs",
+            json={
+                "path": "/path/to/run",
+                "state": "ready",
+            },
+            headers={
+                "Authorization": "secret",
+            },
+        )


### PR DESCRIPTION
Also add tests for the action, and this has much better mocking than what I'm using for testing the cleve service. I should remodel the cleve service tests to use the same approach.