### PR TITLE
refactor: simplify the Illumina directory sensor

### DIFF
--- a/actions/update_run_state.py
+++ b/actions/update_run_state.py
@@ -14,7 +14,7 @@ class UpdateRunState(Action):
         )
 
     def run(self, run_id: str, state: str) -> Dict[str, Any]:
-        return self.cleve.update_run(
+        return self.cleve.update_run_state(
             run_id=run_id,
             state=state,
         )

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -81,7 +81,7 @@ class Cleve:
         if self.key is None:
             raise CleveError("no API key provided")
 
-        uri = f"{self.uri}/runs/{run_id}"
+        uri = f"{self.uri}/runs/{run_id}/path"
         headers = {
             "Authorization": self.key,
         }
@@ -105,7 +105,7 @@ class Cleve:
         if self.key is None:
             raise CleveError("no API key provided")
 
-        uri = f"{self.uri}/runs/{run_id}"
+        uri = f"{self.uri}/runs/{run_id}/state"
         headers = {
             "Authorization": self.key,
         }

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -75,9 +75,33 @@ class Cleve:
 
         return r.json()
 
-    def update_run(self,
-                   run_id: str,
-                   state: str) -> Dict[str, Any]:
+    def update_run_path(self,
+                        run_id: str,
+                        path: str) -> Dict[str, Any]:
+        if self.key is None:
+            raise CleveError("no API key provided")
+
+        uri = f"{self.uri}/runs/{run_id}"
+        headers = {
+            "Authorization": self.key,
+        }
+        payload = {
+            "path": path,
+        }
+
+        r = requests.patch(uri, json=payload, headers=headers)
+
+        if r.status_code != 200:
+            raise CleveError(
+                f"failed to update run {run_id} in {uri}: "
+                f"HTTP {r.status_code} {r.json()}"
+            )
+
+        return r.json()
+
+    def update_run_state(self,
+                         run_id: str,
+                         state: str) -> Dict[str, Any]:
         if self.key is None:
             raise CleveError("no API key provided")
 

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -267,7 +267,7 @@ class IlluminaDirectorySensor(PollingSensor):
                 self._emit_trigger(
                     "state_change",
                     run_id=run_id,
-                    path=str(registered_path),
+                    path=None,
                     state=DirectoryState.MOVED,
                     directory_type=DirectoryType.RUN)
                 # Leave any additional state change for the next poll
@@ -276,6 +276,10 @@ class IlluminaDirectorySensor(PollingSensor):
                 # It has already been handled, or the place to which it
                 # has been moved is not known, so don't do any more
                 # state changes in this round of polling.
+                continue
+            elif not registered_path.is_dir() and registered_state == DirectoryState.MOVED:
+                # The directory has moved, and we don't know where,
+                # don't try to update the state.
                 continue
 
             current_state = self.run_directory_state(registered_path)

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -213,7 +213,8 @@ class IlluminaDirectorySensor(PollingSensor):
                     if state_history:
                         registered_state = state_history[0]["state"]
 
-                    if str(registered_path) != str(dirpath) and registered_state != DirectoryState.MOVED:
+                    if str(registered_path) != str(dirpath) and \
+                            registered_state != DirectoryState.MOVED:
                         # directory has been moved within the watched directories
                         self._logger.debug(f"{dirpath} moved from {registered_path}")
                         self._emit_trigger(
@@ -238,7 +239,9 @@ class IlluminaDirectorySensor(PollingSensor):
 
         return moved_runs
 
-    def _check_existing_runs(self, registered_rundirs: Dict[str, Dict], moved_runs: List[str]) -> None:
+    def _check_existing_runs(self,
+                             registered_rundirs: Dict[str, Dict],
+                             moved_runs: List[str]) -> None:
         """
         Check existing run directories for state changes and new samplesheets.
 

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -269,8 +269,7 @@ class IlluminaDirectorySensor(PollingSensor):
                     directory_type=DirectoryType.RUN)
                 # Leave any additional state change for the next poll
                 continue
-
-            if run_id in moved_runs or registered_state == DirectoryState.MOVED:
+            elif run_id in moved_runs:
                 # It has already been handled, or the place to which it
                 # has been moved is not known, so don't do any more
                 # state changes in this round of polling.

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -72,7 +72,8 @@ class IlluminaDirectorySensor(PollingSensor):
         as well as state changes of existing directories.
         """
         registered_rundirs = self.cleve.get_runs(brief=True)
-        self._check_for_run(registered_rundirs)
+        moved_runs = self._check_new_runs(registered_rundirs)
+        self._check_existing_runs(registered_rundirs, moved_runs)
 
         runs = self.cleve.get_runs(brief=False, platform="NovaSeq", state="ready")
         self._logger.debug(f"found {len(runs)} ready NovaSeq runs")
@@ -148,19 +149,14 @@ class IlluminaDirectorySensor(PollingSensor):
                                "payload found within the last week, "
                                "won't emit new trigger")
 
-    def _check_for_run(self, registered_rundirs: Dict[str, Dict]) -> None:
+    def _check_new_runs(self, registered_rundirs: Dict[str, Dict]) -> List[str]:
         """
-        Check for new run directories, or state changes of existing run
-        directories.
-
-        Emits triggers for new run directories, state changes of existing run
-        directories, and also incomplete run directories where essential
-        information is missing.
+        Check for new run directories within the watched directories.
 
         :param registered_rundirs: Existing run directories
         :type registered_rundirs: dict
         """
-        moved_dirs = set()
+        moved_runs = []
         for wd in self._watched_directories:
             self._logger.debug(f"checking watch directory: {wd}")
 
@@ -209,10 +205,16 @@ class IlluminaDirectorySensor(PollingSensor):
                     )
                     continue
                 self._logger.debug(f"identified run as {run_id}")
+
                 if run_id in registered_rundirs:
                     registered_path = registered_rundirs[run_id]["path"]
-                    if registered_path != str(dirpath):
-                        moved_dirs.add(run_id)
+                    state_history = registered_rundirs[run_id].get("state_history", [])
+                    registered_state = None
+                    if state_history:
+                        registered_state = state_history[0]["state"]
+
+                    if str(registered_path) != str(dirpath) and registered_state != DirectoryState.MOVED:
+                        # directory has been moved within the watched directories
                         self._logger.debug(f"{dirpath} moved from {registered_path}")
                         self._emit_trigger(
                             "state_change",
@@ -220,52 +222,73 @@ class IlluminaDirectorySensor(PollingSensor):
                             path=str(dirpath),
                             state=DirectoryState.MOVED,
                             directory_type=DirectoryType.RUN)
+                        moved_runs.append(run_id)
+                    continue
 
-                    state_history = registered_rundirs[run_id].get("state_history", [])
-                    registered_state = None
-                    if state_history:
-                        registered_state = state_history[0]["state"]
-                    current_state = self.run_directory_state(dirpath)
+                self._logger.debug(f"new directory found: {dirpath}")
+                self._emit_trigger(
+                    "new_directory",
+                    run_id=run_id,
+                    runparameters=str(dirpath / "RunParameters.xml"),
+                    runinfo=str(dirpath / "RunInfo.xml"),
+                    path=str(dirpath),
+                    state=self.run_directory_state(dirpath),
+                    directory_type=DirectoryType.RUN)
+                self._check_for_analysis(run_id, dirpath)
 
-                    if registered_state != current_state:
-                        self._logger.debug(
-                            f"{dirpath} changed state from "
-                            f"{registered_state} to {current_state}"
-                        )
-                        self._emit_trigger(
-                            "state_change",
-                            run_id=run_id,
-                            path=str(dirpath),
-                            state=current_state,
-                            directory_type=DirectoryType.RUN)
-                else:
-                    self._logger.debug(f"new directory found: {dirpath}")
-                    self._emit_trigger(
-                        "new_directory",
-                        run_id=run_id,
-                        runparameters=str(dirpath / "RunParameters.xml"),
-                        runinfo=str(dirpath / "RunInfo.xml"),
-                        path=str(dirpath),
-                        state=self.run_directory_state(dirpath),
-                        directory_type=DirectoryType.RUN)
-                    self._check_for_analysis(run_id, dirpath)
+        return moved_runs
 
-        # Check if existing runs have been moved out of the watched directories
-        for run in registered_rundirs.values():
-            # Don't emit a trigger if the state already is moved
-            state_history = run.get("state_history", [])
-            if state_history and state_history[0]["state"] == DirectoryState.MOVED:
-                continue
-            dirpath = Path(run["path"])
-            if run["run_id"] not in moved_dirs and not dirpath.is_dir():
-                self._logger.debug(f"run {run['run_id']} is missing")
+    def _check_existing_runs(self, registered_rundirs: Dict[str, Dict], moved_runs: List[str]) -> None:
+        """
+        Check existing run directories for state changes and new samplesheets.
+
+        :param registered_rundirs: Existing run directories
+        :type registered_rundirs: dict
+        :param moved_runs: List of run ids that are already known to have been moved
+        :type moved_runs: list
+        """
+        for run_id, rundir in registered_rundirs.items():
+            registered_path = Path(rundir["path"])
+            self._logger.debug(f"checking existing run directory: {registered_path}")
+
+            state_history = registered_rundirs[run_id].get("state_history", [])
+            registered_state = None
+            if state_history:
+                registered_state = state_history[0]["state"]
+
+            if not registered_path.is_dir() and \
+                run_id not in moved_runs and \
+                    registered_state != DirectoryState.MOVED:
+                # Run directory has been moved outside the watched directories
+                # or deleted.
                 self._emit_trigger(
                     "state_change",
-                    run_id=run["run_id"],
-                    path=str(run["path"]),
+                    run_id=run_id,
+                    path=str(registered_path),
                     state=DirectoryState.MOVED,
-                    directory_type=DirectoryType.RUN
+                    directory_type=DirectoryType.RUN)
+                # Leave any additional state change for the next poll
+                continue
+
+            if run_id in moved_runs or registered_state == DirectoryState.MOVED:
+                # It has already been handled, or the place to which it
+                # has been moved is not known, so don't do any more
+                # state changes in this round of polling.
+                continue
+
+            current_state = self.run_directory_state(registered_path)
+
+            if registered_state != current_state:
+                self._logger.debug(
+                    f"{registered_path} changed state from "
+                    f"{registered_state} to {current_state}"
                 )
+                self._emit_trigger(
+                    "state_change",
+                    run_id=run_id,
+                    path=str(registered_path),
+                    state=current_state,
+                    directory_type=DirectoryType.RUN)
 
     def _check_for_analysis(
             self,

--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -34,8 +34,11 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         self.cleve.add_run = Mock(
             side_effect=self._add_run
         )
-        self.cleve.update_run = Mock(
-            side_effect=self._update_run
+        self.cleve.update_run_path = Mock(
+            side_effect=self._update_run_path
+        )
+        self.cleve.update_run_state = Mock(
+            side_effect=self._update_run_state
         )
         self.cleve.add_analysis = Mock(
             side_effect=self._add_analysis
@@ -75,7 +78,10 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
     def _add_run(self, run_id: str, run: Dict[str, Any]):
         self.cleve.runs[run_id] = run
 
-    def _update_run(self, run_id: str, state: str):
+    def _update_run_path(self, run_id: str, path: Union[str, Path]):
+        self.cleve.runs[run_id]["path"] = str(path)
+
+    def _update_run_state(self, run_id: str, state: str):
         self.cleve.runs[run_id]["state_history"].insert(0, {
             "state": state,
             "time": time.time(),


### PR DESCRIPTION
This PR aims at simplifying the Illumina directory sensor in order for it to me more readable and maintainable. As a consequence of this, some things have also changed. Perhaps the most important thing to consider is that if a run directory is moved, and the sensor can figure out the new location, the run will have get state of `moved` from the first poll. This trigger should result in the state of the run being set to `moved` and the path to be updated. On poll following this, the actual state of the run will be detected, and the run will be updated accordingly.

For this to work as intended, a new rule and action for updating the run path must be implemented. See  #31.