### PR TITLE
feat: add handling for samplesheets

### DIFF
--- a/actions/update_samplesheet.py
+++ b/actions/update_samplesheet.py
@@ -1,0 +1,23 @@
+from cleve_service import Cleve
+from st2common.runners.base_action import Action
+from typing import Any, Dict
+
+
+class UpdateSampleSheet(Action):
+
+    def __init__(self, config, action_service):
+        super().__init__(config, action_service)
+        if "cleve_service" in self.config:
+            self.cleve = self.config.get("cleve_service")
+        else:
+            self.cleve = Cleve(
+                config.get("cleve").get("host"),
+                config.get("cleve").get("port"),
+                config.get("cleve").get("api_key"),
+            )
+
+    def run(self, run_id: str, samplesheet: str) -> Dict[str, Any]:
+        return self.cleve.update_samplesheet(
+            run_id=run_id,
+            samplesheet=samplesheet,
+        )

--- a/actions/update_samplesheet.yaml
+++ b/actions/update_samplesheet.yaml
@@ -1,0 +1,18 @@
+---
+name: update_samplesheet
+runner_type: python-script
+description: Update the samplesheet for a run
+enabled: true
+entry_point: update_samplesheet.py
+
+parameters:
+  run_id:
+    type: string
+    description: The ID of the run
+    position: 0
+    required: true
+  state:
+    type: string
+    description: The path to the samplesheet
+    position: 1
+    required: true

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -123,6 +123,30 @@ class Cleve:
 
         return r.json()
 
+    def update_samplesheet(self,
+                           run_id: str,
+                           samplesheet: str) -> Dict[str, Any]:
+        if self.key is None:
+            raise CleveError("no API key provided")
+
+        uri = f"{self.uri}/runs/{run_id}/samplesheet"
+        headers = {
+            "Authorization": self.key,
+        }
+        payload = {
+            "samplesheet": samplesheet,
+        }
+
+        r = requests.post(uri, json=payload, headers=headers)
+
+        if r.status_code != 200:
+            raise CleveError(
+                f"failed to update samplesheet for run {run_id} in {uri}: "
+                f"HTTP {r.status_code} {r.json()}"
+            )
+
+        return r.json()
+
     def add_run_qc(self, run_id: str) -> Dict[str, Any]:
         if self.key is None:
             raise CleveError("no API key provided")

--- a/rules/update_samplesheet.yaml
+++ b/rules/update_samplesheet.yaml
@@ -1,0 +1,14 @@
+---
+name: update_samplesheet
+description: Rule for updating the samplesheet for a run
+pack: gmc_norr_seqdata
+enabled: true
+
+trigger:
+  type: gmc_norr_seqdata.new_samplesheet
+
+action:
+  ref: gmc_norr_seqdata.update_samplesheet
+  parameters:
+    run_id: "{{ trigger.run_id }}"
+    samplesheet: "{{ trigger.samplesheet }}"

--- a/sensors/illumina_directory_sensor.yaml
+++ b/sensors/illumina_directory_sensor.yaml
@@ -132,3 +132,19 @@ trigger_types:
           type: string
           description: A message describing why the directory is incomplete
           required: false
+
+  - name: new_samplesheet
+    pack: gmc_norr_seqdata
+    description: >
+      Triggers when a new samplesheet is found for a run.
+    payload_schema:
+      type: object
+      properties:
+        run_id:
+          type: string
+          description: The ID of the run
+          required: true
+        samplesheet:
+          type: string
+          description: The path to the samplesheet
+          required: true

--- a/tests/test_action_update_samplesheet.py
+++ b/tests/test_action_update_samplesheet.py
@@ -1,0 +1,44 @@
+from unittest.mock import Mock
+
+import cleve_service
+from st2tests.base import BaseActionTestCase
+
+from actions.update_samplesheet import UpdateSampleSheet
+
+
+def mock_post(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+    return MockResponse({"message": "samplesheet updated"}, 200)
+
+
+class UpdateSampleSheetTestCase(BaseActionTestCase):
+    action_cls = UpdateSampleSheet
+
+    def setUp(self):
+        super(UpdateSampleSheetTestCase, self).setUp()
+
+        self.cleve = cleve_service.Cleve(key="secret")
+        self.action = self.get_action_instance(config={
+            "cleve_service": self.cleve
+        })
+
+    def test_update_samplesheet(self):
+        cleve_service.requests.post = Mock(side_effect=mock_post)
+        self.action.run(run_id="run1", samplesheet="/path/to/samplesheet")
+
+        cleve_service.requests.post.assert_called_with(
+            "http://localhost:8080/api/runs/run1/samplesheet",
+            json={
+                "samplesheet": "/path/to/samplesheet",
+            },
+            headers={
+                "Authorization": "secret",
+            },
+        )


### PR DESCRIPTION
This is triggered in a couple of scenarios:

1. A run doesn't have a samplesheet associated with it and any samplesheet is found for the run.
2. A run has a samplesheet associated with it, but a samplesheet with a more recent modification time is found in the run directory.

Currently, the samplesheet is required to be in the root of the run directory, and it needs to have a prefix of `samplesheet` (case insensitive), and a suffix of `.csv`.