### PR TITLE
fix: don't emit duplicate run triggers too frequently

### DIFF
--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -696,3 +696,13 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
                 "email": ["me@mail.com"],
             }
         )
+
+        # Mock a trigger instance in the database
+        self.sensor._find_duplicate_run_trigger = Mock(
+            return_value="mock_trigger_instance"
+        )
+
+        # No new triggers should be emitted since a recent trigger instance
+        # already exists.
+        self.sensor.poll()
+        self.assertEqual(len(self.get_dispatched_triggers()), 1)


### PR DESCRIPTION
If a duplicate run trigger with the same payload as the one that is about to be emitted, and it is less than a week old, then don't emit the trigger. Otherwise the trigger would be emitted on every poll, and that would very quickly become annoying.