### PR TITLE
fix: time zone issue with sample sheet update

### DIFF
--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -383,13 +383,17 @@ class IlluminaDirectorySensor(PollingSensor):
         """
         samplesheets = path.glob("[Ss]ample[Ss]heet*.csv")
         mod_times = []
+        current_tz = datetime.now(timezone.utc).astimezone().tzinfo
         for ss in samplesheets:
             info = ss.stat()
-            modification_time = datetime.fromtimestamp(info.st_mtime, tz=timezone.utc)
+            modification_time = datetime.fromtimestamp(
+                info.st_mtime,
+                tz=current_tz
+            )
             modification_time = modification_time.replace(microsecond=0)
             mod_times.append((ss, modification_time))
 
-        mod_times = sorted(mod_times, reverse=True)
+        mod_times = sorted(mod_times, key=lambda x: x[1], reverse=True)
 
         if len(mod_times) == 0:
             return

--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -1,10 +1,11 @@
+from dataclasses import dataclass
 import datetime
 import os
 from pathlib import Path
 from st2tests.base import BaseSensorTestCase
 import tempfile
 import time
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from unittest.mock import Mock
 
 from illumina_directory_sensor import (
@@ -668,6 +669,113 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
         })
 
         # No trigger should be emitted
+        self.sensor.poll()
+        self.assertEqual(len(self.get_dispatched_triggers()), 0)
+
+    def test_find_samplesheet(self):
+        @dataclass
+        class TestCase:
+            samplesheets: List[Path]
+            modtimes: List[datetime.datetime]
+            expect: str
+
+        run_directory = Path(self.watch_directories[0].name) / "run1"
+        run_directory.mkdir()
+
+        testcases = [
+            TestCase(
+                samplesheets=[
+                    run_directory / "SampleSheet.csv",
+                ],
+                modtimes=[
+                    datetime.datetime(2024, 9, 4, 15, 23),
+                ],
+                expect=str(run_directory / "SampleSheet.csv"),
+            ),
+            TestCase(
+                samplesheets=[
+                    run_directory / "SampleSheet.csv",
+                    run_directory / "SampleSheet_final.csv",
+                    run_directory / "SampleSheet_old.csv",
+                ],
+                modtimes=[
+                    datetime.datetime(2024, 9, 4, 15, 23),
+                    datetime.datetime(2024, 9, 4, 15, 50),
+                    datetime.datetime(2024, 9, 4, 15, 0),
+                ],
+                expect=str(run_directory / "SampleSheet_final.csv"),
+            ),
+        ]
+
+        for n, case in enumerate(testcases, start=1):
+            for s, t in zip(case.samplesheets, case.modtimes):
+                s.touch()
+                os.utime(s, (t.timestamp(), t.timestamp()))
+
+            self.sensor._find_samplesheet(run_id="run1", path=run_directory)
+            self.assertEqual(len(self.get_dispatched_triggers()), n)
+            self.assertTriggerDispatched(
+                trigger="gmc_norr_seqdata.new_samplesheet",
+                payload={
+                    "run_id": "run1",
+                    "samplesheet": case.expect,
+                })
+
+            for s in case.samplesheets:
+                s.unlink()
+
+    def test_update_samplesheet(self):
+        run_directory = Path(self.watch_directories[0].name) / "run1"
+        run_directory.mkdir()
+        (run_directory / "CopyComplete.txt").touch()
+        self._write_basic_runparams(run_directory, "NovaSeq", "run1")
+        self._write_basic_runinfo(run_directory, "NovaSeq", "run1")
+        original_samplesheet = (run_directory / "SampleSheet.csv")
+        old_samplesheet = (run_directory / "SampleSheet_old.csv")
+
+        original_samplesheet.touch()
+        old_samplesheet.touch()
+
+        # File modification time is local, i.e. CEST
+        modtime = datetime.datetime(
+            2024, 9, 3, 8, 40,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=2))
+        )
+        oldtime = datetime.datetime(
+            2024, 9, 3, 8, 18,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=2))
+        )
+
+        os.utime(
+            original_samplesheet,
+            (modtime.timestamp(), modtime.timestamp())
+        )
+        os.utime(
+            old_samplesheet,
+            (oldtime.timestamp(), oldtime.timestamp())
+        )
+
+        # Server modification time is in UTC
+        server_modtime = modtime.astimezone(datetime.timezone.utc)
+
+        self.cleve.add_run("run1", {
+            "run_id": "run1",
+            "platform": "NovaSeq",
+            "state_history": [{
+                "state": DirectoryState.READY,
+                "time": time.localtime(),
+            }],
+            "samplesheet": {
+                "path": str(original_samplesheet),
+                "modification_time": server_modtime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            },
+            "path": str(run_directory),
+            "analysis": [],
+        })
+
+        # No trigger should be dispatched since the modification time of the
+        # most recent sample sheet on disk is the same as the one in the
+        # database, just different time zones.
         self.sensor.poll()
         self.assertEqual(len(self.get_dispatched_triggers()), 0)
 

--- a/tests/test_sensor_run_directory_sensor.py
+++ b/tests/test_sensor_run_directory_sensor.py
@@ -777,7 +777,8 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
             }],
             "samplesheet": {
                 "path": str(original_samplesheet),
-                "modification_time": server_modtime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "modification_time":
+                    server_modtime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             },
             "path": str(run_directory),
             "analysis": [],
@@ -799,11 +800,16 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
 
         samplesheet.touch()
 
-        original_modtime = datetime.datetime(2024, 6, 20, 13, 9, 3, 617123)
+        original_modtime = datetime.datetime(
+            2024, 6, 20, 13, 9, 3, 617123,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=2)),
+        )
         os.utime(
             samplesheet,
-            (original_modtime.timestamp(), original_modtime.timestamp())
+            (original_modtime.timestamp(), original_modtime.timestamp()),
         )
+
+        server_modtime = original_modtime.astimezone(datetime.timezone.utc)
 
         # The new samplesheet is technically newer than what is in the
         # database, but this could be due to the modification time being
@@ -819,7 +825,8 @@ class IlluminaDirectorySensorTestCase(BaseSensorTestCase):
             }],
             "samplesheet": {
                 "path": str(run_directory / "SampleSheet.csv"),
-                "modification_time": "2024-06-20T13:09:03.617Z",
+                "modification_time":
+                    server_modtime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             },
             "path": str(run_directory),
             "analysis": [],


### PR DESCRIPTION
This PR addresses an issue where time zones weren't handled properly when detecting new sample sheets. It really consisted of two issues: the sorting of the sample sheets on disk was incorrect, and the file modification timestamp was parsed incorrectly.

Now the file modification times should be relative to the time zone of the StackStorm server where the file is being detected, and the server modification time still is in UTC. Added tests show that the behaviour is now what I would expect.