### PR TITLE
fix: update sample sheet if the registered file is missing

### DIFF
--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -351,7 +351,7 @@ class IlluminaDirectorySensor(PollingSensor):
 
             # Find any new samplesheets
             samplesheet_info = rundir.get("samplesheet")
-            if not samplesheet_info:
+            if not samplesheet_info or not Path(samplesheet_info.get("path")).exists():
                 samplesheet_modtime = None
             else:
                 mod_time_str = samplesheet_info.get("modification_time")


### PR DESCRIPTION
If a registered sample sheet doesn't exist on disk, no update would be performed. This addresses this by checking if the registered file is missing, and if so, the modification time is disregarded, resulting in the most recent sample sheet being assigned to the run.