### PR TITLE
fix: don't try to update run path if it is missing

### DIFF
--- a/actions/workflows/run_state_workflow.yaml
+++ b/actions/workflows/run_state_workflow.yaml
@@ -25,15 +25,13 @@ tasks:
       state: <% ctx().state %>
     next:
       - when: <% succeeded() and ctx().state = "ready" %>
-        publish:
-          - state_result: <% result() %>
         do:
           - add_run_qc
       - when: <% succeeded() and ctx().state = "moved" and ctx().path != null %>
-        publish:
-          - state_result: <% result() %>
         do:
           - update_run_path
+      - publish:
+          - state_result: <% result() %>
 
   add_run_qc:
     action: gmc_norr_seqdata.add_run_qc

--- a/actions/workflows/run_state_workflow.yaml
+++ b/actions/workflows/run_state_workflow.yaml
@@ -29,7 +29,7 @@ tasks:
           - state_result: <% result() %>
         do:
           - add_run_qc
-      - when: <% succeeded() and ctx().state = "moved" %>
+      - when: <% succeeded() and ctx().state = "moved" and ctx().path != null %>
         publish:
           - state_result: <% result() %>
         do:


### PR DESCRIPTION
When a run is moved outside the watched directories, the run path will be unknown. In these cases the state of the run should be kept as moved, but the path should be the last known path for the run. This PR fixes an issue where an attempt to update the run path when it was unknown. This did not result in an actual update of the run path, but the workflow did fail due to faulty input to the `update_run_path` action.