### PR TITLE
feat: properly detect moved analysis directories

### DIFF
--- a/actions/update_analysis.py
+++ b/actions/update_analysis.py
@@ -20,10 +20,12 @@ class UpdateAnalysisAction(Action):
             run_id: str,
             analysis_id: str,
             state: str,
+            path: str,
             summary_file: Optional[str] = None) -> Dict[str, Any]:
         return self.cleve.update_analysis(
             run_id=run_id,
             analysis_id=analysis_id,
+            path=path,
             state=state,
             summary_file=summary_file,
         )

--- a/actions/update_analysis.py
+++ b/actions/update_analysis.py
@@ -19,8 +19,8 @@ class UpdateAnalysisAction(Action):
     def run(self,
             run_id: str,
             analysis_id: str,
-            state: str,
-            path: str,
+            state: Optional[str] = None,
+            path: Optional[str] = None,
             summary_file: Optional[str] = None) -> Dict[str, Any]:
         return self.cleve.update_analysis(
             run_id=run_id,

--- a/actions/update_analysis.yaml
+++ b/actions/update_analysis.yaml
@@ -17,6 +17,10 @@ parameters:
     type: string
     description: The state of the run
     required: false
+  path
+    type: string
+    description: The path to the analysis directory
+    required: false
   summary_file:
     type: string
     description: The path to the summary JSON

--- a/actions/update_analysis.yaml
+++ b/actions/update_analysis.yaml
@@ -17,7 +17,7 @@ parameters:
     type: string
     description: The state of the run
     required: false
-  path
+  path:
     type: string
     description: The path to the analysis directory
     required: false

--- a/lib/cleve_service.py
+++ b/lib/cleve_service.py
@@ -205,6 +205,7 @@ class Cleve:
                         run_id: str,
                         analysis_id: str,
                         state: Optional[str],
+                        path: Optional[str],
                         summary_file: Optional[str]) -> Dict[str, Any]:
         if self.key is None:
             raise CleveError("no API key provided")
@@ -216,6 +217,8 @@ class Cleve:
 
         if state is not None:
             files["state"] = (None, state)
+        if path is not None:
+            files["path"] = (None, path)
 
         if summary_file is not None:
             files["summary_file"] = (

--- a/rules/update_analysis.yaml
+++ b/rules/update_analysis.yaml
@@ -17,5 +17,6 @@ action:
   parameters:
     run_id: "{{ trigger.run_id }}"
     analysis_id: "{{ trigger.analysis_id }}"
+    path: "{{ trigger.path }}"
     state: "{{ trigger.state }}"
     summary_file: "{{ trigger.summary_file | use_none }}"

--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -435,7 +435,7 @@ class IlluminaDirectorySensor(PollingSensor):
 
         analyses = {}
         for a in existing_analyses or []:
-            analyses[a["path"]] = a
+            analyses[a["analysis_id"]] = a
 
         root, analysis_dirs, _ = next(os.walk(analysis_path))
 
@@ -459,11 +459,11 @@ class IlluminaDirectorySensor(PollingSensor):
                     f"found detailed summary at {detailed_summary}"
                 )
 
-            if str(dirpath) in analyses:
+            if analysis_id in analyses:
                 self._logger.debug(
                     "analysis dir has been registered for run, checking state"
                 )
-                registered_state = analyses[str(dirpath)]["state"]
+                registered_state = analyses[analysis_id]["state"]
                 current_state = self.analysis_directory_state(dirpath)
                 if registered_state != current_state:
                     self._logger.debug(f"{dirpath} changed state "

--- a/tests/test_action_update_analysis.py
+++ b/tests/test_action_update_analysis.py
@@ -79,3 +79,21 @@ class UpdateAnalyisTestCase(BaseActionTestCase):
                 "Authorization": "secret",
             },
         )
+
+    def test_update_analysis_path(self):
+        cleve_service.requests.patch = Mock(side_effect=mock_response)
+        self.action.run(
+            run_id="run1",
+            analysis_id="1",
+            path="/path/to/analysis/1",
+        )
+
+        cleve_service.requests.patch.assert_called_with(
+            "http://localhost:8080/api/runs/run1/analysis/1",
+            files={
+                "path": (None, "/path/to/analysis/1"),
+            },
+            headers={
+                "Authorization": "secret",
+            },
+        )


### PR DESCRIPTION
This PR adds the ability for the sensor to properly handle analysis directories for NovaSeq runs that have been moved. It now uses the analysis ID instead of the path to identify analyses, and if the run has been moved together with the analysis, a state_change trigger is emitted to reflect this.

In addition to this, the rule and associated action for updating the analysis now also includes the path. This will require a change in the Cleve API to also accept a path in the analysis update endpoint.

I think that I have test coverage for the most obvious things, and they all pass locally.