### PR TITLE
fix: catch StopIteration when checking analysis dir

### DIFF
--- a/sensors/illumina_directory_sensor.py
+++ b/sensors/illumina_directory_sensor.py
@@ -439,7 +439,11 @@ class IlluminaDirectorySensor(PollingSensor):
         for a in existing_analyses or []:
             analyses[a["analysis_id"]] = a
 
-        root, analysis_dirs, _ = next(os.walk(analysis_path))
+        try:
+            root, analysis_dirs, _ = next(os.walk(analysis_path))
+        except StopIteration:
+            LOG.warn(f"StopIteration when checking analysis directory {analysis_path} for run {run_id}")
+            return
 
         for analysis_dir in analysis_dirs:
             dirpath = Path(root) / str(analysis_dir)


### PR DESCRIPTION
For some reason we sometimes see a StopIteration exception when checking the analysis directories. The existence of the directory is checked befor this, so I don't really understand where the error comes from. This will now print a warning and return from the function in order to prevent the sensor from crashing.