### PR TITLE
chore: add cleve dependency

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -5,5 +5,7 @@ description: GMC Norr pack for handling sequencing data
 version: 0.4.1 # x-release-please-version
 python_versions:
   - "3"
+dependencies:
+  - https://github.com/gmc-norr/st2-cleve=1.0.1
 author: Niklas Mähler
 email: niklas.mahler@regionvasterbotten.se


### PR DESCRIPTION
This adds a dependency on the cleve pack. It currently is set to the most recent release, so we will have to be sure to update this if anything changes.

BEGIN_COMMIT_OVERRIDE
fix: add cleve dependency
END_COMMIT_OVERRIDE