### PR TITLE
feat: add `copy bam` workflow

### DIFF
--- a/actions/copy_bam.yaml
+++ b/actions/copy_bam.yaml
@@ -1,0 +1,26 @@
+name: copy_interop
+runner_type: orquesta
+description: Copy the bam folder from an analysis
+enabled: true
+entry_point: workflows/copy_bam.yaml
+
+parameters:
+  bam_path:
+    type: string
+    required: true
+    description: Path to sequencing run
+  run_id:
+    type: string
+    required: true
+    description: Run that generated the fastq files that the analysis is baseed on
+  pipeline:
+    type: string
+    required: true
+    description: Pipeline that generated
+  destination:
+    type: string
+    required: false
+    description: >
+      Base directory where the bam files should be copied to. If missing,
+      an attempt to fetch it from the pack config is made. If the directory
+      doesn't exist it will be created.

--- a/actions/copy_bam.yaml
+++ b/actions/copy_bam.yaml
@@ -1,4 +1,4 @@
-name: copy_interop
+name: copy_bam
 runner_type: orquesta
 description: Copy the bam folder from an analysis
 enabled: true

--- a/actions/get_file_destination.yaml
+++ b/actions/get_file_destination.yaml
@@ -15,6 +15,7 @@ parameters:
     enum:
       - interop
       - run
+      - bam
   platform:
     type: string
     required: true

--- a/actions/workflows/copy_bam.yaml
+++ b/actions/workflows/copy_bam.yaml
@@ -56,7 +56,7 @@ tasks:
   copy_bam_folder:
     action: core.local
     input:
-      cmd: "rsync -aP <% ctx(bam_path) %> <% ctx(destination) %>"
+      cmd: "rsync -a <% ctx(bam_path) %> <% ctx(destination) %>"
       timeout: 9000
     next:
       - when: <% failed() %>

--- a/actions/workflows/copy_bam.yaml
+++ b/actions/workflows/copy_bam.yaml
@@ -34,7 +34,7 @@ tasks:
         do: fail
       - when: <% succeeded() and result().result = null %>
         publish:
-          - err: "destination not defined for platform: <% ctx(platform) %>"
+          - err: "destination not defined for platform: <% ctx(pipeline) %>"
         do: fail
       - when: <% succeeded() and result().result != null %>
         publish:

--- a/actions/workflows/copy_bam.yaml
+++ b/actions/workflows/copy_bam.yaml
@@ -1,0 +1,72 @@
+version: 1.0
+description: >
+  Copy bam from an analysis to a shared directory
+  that can be accessed by more people.
+
+input:
+  - bam_path
+  - run_id
+  - pipeline
+  - destination
+
+vars:
+  - err:
+  - msg:
+
+tasks:
+  check_destination:
+    action: core.noop
+    next:
+      - when: <% succeeded() and ctx(destination) = null %>
+        do: get_destination
+      - when: <% succeeded() and ctx(destination) != null %>
+        do: create_destination
+
+  get_destination:
+    action: gmc_norr_seqdata.get_file_destination
+    input:
+      type: bam
+      platform: <% ctx(pipeline) %>
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: "failed to get destination from pack config"
+        do: fail
+      - when: <% succeeded() and result().result = null %>
+        publish:
+          - err: "destination not defined for platform: <% ctx(platform) %>"
+        do: fail
+      - when: <% succeeded() and result().result != null %>
+        publish:
+          - destination: <% result().result %>/<% ctx().run_id %>
+        do: create_destination
+
+  create_destination:
+    action: core.local
+    input:
+      cmd: "mkdir -p <% ctx(destination) %>"
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: "failed to create destination directory"
+        do: fail
+      - when: <% succeeded() %>
+        do: copy_bam_folder
+
+  copy_bam_folder:
+    action: core.local
+    input:
+      cmd: "rsync -aP <% ctx(bam_path) %> <% ctx(destination) %>"
+      timeout: 9000
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: "rsync failed: <% result().stderr %>"
+        do: fail
+      - when: <% succeeded() %>
+        publish:
+          - msg: "data synced to <% ctx(destination) %> %>"
+
+output:
+  - message: <% ctx(msg) %>
+  - error: <% ctx(err) %>

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -39,3 +39,18 @@ run_destinations:
       path:
         type: string
         required: true
+
+bam_destinations:
+  description: >
+    Pipeline specific locations where bam files should be moved.
+  type: array
+  required: true
+  items:
+    type: object
+    properties:
+      platform:
+        type: string
+        required: true
+      path:
+        type: string
+        required: true


### PR DESCRIPTION
Cheating a bit in using the pipeline as the platform parameter for get_file_destination, but I think that's most convenient. Although the mix of pipeline and platform might be confusing?

The pack has several similar action now, which could probably be consolidated, but since the destination always looks different that might just become messy. So far this pack is pretty empty anyways. Alternatively, we could make the file type a parameter and use this for simpler copy actions (lymphotrack and KITM need to check that the run is of right type, so they are out, though.) We'd still need to add the file types to the config... unless we change that up too, and only have a generic ```destinations``` config parameter.

The action has been tested in my local space, where it managed to copy files. The rest just depends on if the paths are correct, I guess. As follows from rsyncs normal behaviour, depending on if the bam_path has a trailing slash or not we get the contents of the directory or its contents, which I think is fine. 

