### PR TITLE
feat: add copy lymphotrack action and rule

### DIFF
--- a/actions/copy_lymphotrack.yaml
+++ b/actions/copy_lymphotrack.yaml
@@ -1,0 +1,11 @@
+name: copy_lymphotrack
+runner_type: orquesta
+description: Copy the fastq direcotry for a lymphotrack run
+enabled: true
+entry_point: workflows/copy_lymphotrack.yaml
+
+parameters:
+  analysis_id:
+    type: string
+    required: true
+    description: ID of the analysis

--- a/actions/get_file_destination.yaml
+++ b/actions/get_file_destination.yaml
@@ -15,6 +15,7 @@ parameters:
     enum:
       - interop
       - run
+      - fastq
   platform:
     type: string
     required: true

--- a/actions/workflows/copy_lymphotrack.yaml
+++ b/actions/workflows/copy_lymphotrack.yaml
@@ -1,0 +1,142 @@
+version: 1.0
+name: copy_lymphotrack
+description: >
+  Copy fastq dir for lymphotrack runs from BCLConvert to a shared directory
+  that can be accessed by more people.
+
+input:
+  - analysis_id
+
+vars:
+  - err:
+  - msg:
+  - run_id:
+  - run_path:
+  - platform:
+
+tasks:
+  get_run_id:
+    action: cleve.get_analyses
+    input:
+      analysis_id: <% ctx().analysis_id %>
+    next:
+      - when: <% failed() %>
+        publish:
+          - msg: Cleve not reachable
+        do: fail
+      - when: <% succeeded() and result().result.body.metadata.count = 0 %>
+        publish:
+          - msg: analysis <% ctx().analysis_id %> not found in Cleve
+        do: fail
+      - when: <% succeeded() and result().result.body.metadata.count > 1 %>
+        publish:
+          - msg: more than one analysis with ID <% ctx().analysis_id %> found in Cleve
+        do: fail
+      - when: <% succeeded() and result().result.body.metadata.count = 1 %>
+        publish:
+          - run_id: <% result().result.body.analyses.first().runs.first() %>
+        do: get_run_description
+
+  get_run_description:
+    action: cleve.get_samplesheet
+    input:
+      run_id: <% ctx(run_id) %>
+      section: Header
+      key: RunDescription
+    next:
+      - when: "{{ succeeded() and 'lymphotrack' in result().get('result').get('body') | lower }}"
+        do: get_fastq_file
+      - when: "{{ succeeded() and 'lymphotrack' not in result().get('result').get('body') | lower }}"
+        publish:
+          - msg: "Not a lymphotrack run."
+        do: noop
+      - when: "{{ failed() and result().get('result').get('body').get('error') == 'key RunDescription not found in section Header' }}"
+        publish:
+          - msg: "No RunDescription in samplesheet"
+        do: noop
+      - when: "{{ failed() }}"
+        publish:
+          - err: "Failed to get samplesheet data from Cleve.
+              {{ result() | to_json_string }}"
+        do: fail
+
+  get_fastq_file:
+    action: cleve.get_analysis_files
+    input:
+      analysis_id: <% ctx(analysis_id) %>
+      type: fastq
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: <% result().result.body.error %>
+        do: fail
+      - when: <% succeeded() and result().result.body.len() = 0 %>
+        publish:
+          - err: "no fastq files found"
+        do: fail
+      - when: <% succeeded() and result().result.body.len() > 0 %>
+        publish:
+          - fastq_file: <% result().result.body.first().path %>
+        do: get_fastq_dir # assuming all fastq files are in the same dir
+
+  get_fastq_dir:
+    action: core.local
+    input:
+      cmd: "dirname {{ ctx().fastq_file }}"
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: <% result().result.body.error %>
+        do: fail
+      - when: <% succeeded() %>
+        publish:
+          - fastq_dir: <% result().stdout %>/ # because we only want the contents
+        do: get_destination
+
+  get_destination:
+    action: gmc_norr_seqdata.get_file_destination
+    input:
+      type: fastq
+      platform: lymphotrack
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: "failed to get destination from pack config"
+        do: fail
+      - when: <% succeeded() and result().result = null %>
+        publish:
+          - err: "destination not defined for platform: lymphotrack %>"
+        do: fail
+      - when: <% succeeded() and result().result != null %>
+        publish:
+          - destination: <% result().result %>/<% ctx(run_id) %>
+        do: create_destination
+
+  create_destination:
+    action: core.local
+    input:
+      cmd: "mkdir -p <% ctx(destination) %>"
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: "failed to create destination directory"
+        do: fail
+      - when: <% succeeded() %>
+        do: copy_fastq_dir
+
+  copy_fastq_dir:
+    action: core.local
+    input:
+      cmd: "rsync -a <% ctx(fastq_dir) %> <% ctx(destination) %>"
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: "rsync failed: <% result().stderr %>"
+        do: fail
+      - when: <% succeeded() %>
+        publish:
+          - msg: "indexmetrics synced to <% ctx(destination) %>"
+
+output:
+  - message: <% ctx(msg) %>
+  - error: <% ctx(err) %>

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -39,3 +39,18 @@ run_destinations:
       path:
         type: string
         required: true
+
+fastq_destinations:
+  description: >
+    Platform specific locations where fastq files should be moved.
+  type: array
+  required: true
+  items:
+    type: object
+    properties:
+      platform:
+        type: string
+        required: true
+      path:
+        type: string
+        required: true

--- a/rules/copy_lymphotrack.yaml
+++ b/rules/copy_lymphotrack.yaml
@@ -1,0 +1,27 @@
+---
+name: copy_indexmetrics
+description: >
+  Rule for checking if a BCLConvert run belongs to a
+  lymphotrack sequenicng run, and if so, move the fastq
+  folder to a shared directory
+pack: gmc_norr_seqdata
+enabled: true
+
+trigger:
+  type: cleve.analysis_state_update
+
+criteria:
+  trigger.state:
+    type: equals
+    pattern: ready
+  trigger.software:
+    type: contains
+    pattern: BCLConvert
+  trigger.path:
+    type: contains
+    pattern: miseq
+
+action:
+  ref: gmc_norr_seqdata.copy_lymphotrack
+  parameters:
+    analysis_id: "{{ trigger.analysis_id }}"


### PR DESCRIPTION
Specifically copies the fastq files of any run with lymphotrack in the run description. Only triggered by ready BCLConvert analyses with miseq in the path since they should only be run on them, and I want to avoid checking for every run. Replaces the lymphotrack pack, which had its own sensor.