### PR TITLE
feat: add copy kitm run action and rule

### DIFF
--- a/actions/copy_kitm_run.yaml
+++ b/actions/copy_kitm_run.yaml
@@ -1,0 +1,26 @@
+name: copy_kitm_run
+runner_type: orquesta
+description: If run has kitm in run description, copy run to shared destination
+enabled: true
+entry_point: workflows/copy_kitm_run.yaml
+
+parameters:
+  run_path:
+    type: string
+    required: true
+    description: Path to sequencing run
+  run_id:
+    type: string
+    required: true
+    description: ID of the sequencing run
+  platform:
+    type: string
+    required: true
+    description: Platform that was used for the sequencing
+  destination:
+    type: string
+    required: false
+    description: >
+      Base directory where the run should be copied to. If missing,
+      an attempt to fetch it from the pack config is made. If the directory
+      doesn't exist it will be created.

--- a/actions/workflows/copy_kitm_run.yaml
+++ b/actions/workflows/copy_kitm_run.yaml
@@ -1,0 +1,93 @@
+version: 1.0
+description: >
+  Check if run is KITM, if so, copy run to a shared directory.
+
+input:
+  - run_path
+  - run_id
+  - platform
+  - destination
+
+vars:
+  - err:
+  - msg:
+
+tasks:
+  get_run_description:
+    action: cleve.get_samplesheet
+    input:
+      run_id: <% ctx(run_id) %>
+      section: Header
+      key: RunDescription
+    next:
+      - when: "{{ succeeded() and 'kitm' in result().get('result').get('body') | lower }}"
+        publish:
+          - source: <% ctx(run_path)%>/
+          - file_type: run
+        do:
+          get_destination
+      - when: "{{ succeeded() and 'kitm' not in result().get('result').get('body') | lower }}"
+        publish:
+          - msg: "Not a KITM run."
+        do:
+          noop
+      - when: "{{ failed() and result().get('result').get('body').get('error') == 'key RunDescription not found in section Header' }}"
+        publish:
+          - msg: "No RunDescription in samplesheet"
+        do:
+          noop
+      - when: "{{ failed() }}"
+        publish:
+          - err: "Failed to get samplesheet data from Cleve.
+              {{ result() | to_json_string }}"
+        do:
+          fail
+
+  get_destination:
+    action: gmc_norr_seqdata.get_file_destination
+    input:
+      type: run
+      platform: <% ctx(platform) %>
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: "failed to get destination from pack config"
+        do: fail
+      - when: <% succeeded() and result().result = null %>
+        publish:
+          - err: "destination not defined for platform: <% ctx(platform) %>"
+        do: fail
+      - when: <% succeeded() and result().result != null %>
+        publish:
+          - destination: <% result().result %>
+        do: create_destination
+
+  create_destination:
+    action: core.local
+    input:
+      cmd: "mkdir -p <% ctx(destination) %>"
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: "failed to create destination directory"
+        do: fail
+      - when: <% succeeded() %>
+        do: copy_run
+
+  copy_run:
+    action: core.local
+    input:
+      cmd: "rsync -a <% ctx(run_path) %> <% ctx(destination) %>"
+      timeout: 9000
+    next:
+      - when: <% failed() %>
+        publish:
+          - err: "rsync failed: <% result().stderr %>"
+        do: fail
+      - when: <% succeeded() %>
+        publish:
+          - msg: "data synced to <% ctx(destination) %>/<% ctx(run_id) %>"
+
+output:
+  - message: <% ctx(msg) %>
+  - error: <% ctx(err) %>

--- a/actions/workflows/copy_kitm_run.yaml
+++ b/actions/workflows/copy_kitm_run.yaml
@@ -21,9 +21,6 @@ tasks:
       key: RunDescription
     next:
       - when: "{{ succeeded() and 'kitm' in result().get('result').get('body') | lower }}"
-        publish:
-          - source: <% ctx(run_path)%>/
-          - file_type: run
         do:
           get_destination
       - when: "{{ succeeded() and 'kitm' not in result().get('result').get('body') | lower }}"
@@ -47,7 +44,7 @@ tasks:
     action: gmc_norr_seqdata.get_file_destination
     input:
       type: run
-      platform: <% ctx(platform) %>
+      platform: <% ctx(platform) %> # KITM maybe? Just needs to match config
     next:
       - when: <% failed() %>
         publish:
@@ -60,6 +57,7 @@ tasks:
       - when: <% succeeded() and result().result != null %>
         publish:
           - destination: <% result().result %>
+          - run_path: "{{ ctx().run_path.rstrip('/') }}"
         do: create_destination
 
   create_destination:

--- a/rules/copy_kitm_run.yaml
+++ b/rules/copy_kitm_run.yaml
@@ -1,0 +1,25 @@
+---
+name: copy_kitm_run
+description: >
+  Rule for copying checking if Miseq i100 runs are KITM,
+  and copying it to a shared directory
+pack: gmc_norr_seqdata
+enabled: true
+
+trigger:
+  type: cleve.run_state_update
+
+criteria:
+  trigger.state:
+    type: equals
+    pattern: ready
+  trigger.platform:
+    type: equals
+    pattern: 'MiSeq i100'
+
+action:
+  ref: gmc_norr_seqdata.copy_kitm_run
+  parameters:
+    run_id: "{{ trigger.run_id }}"
+    run_path: "{{ trigger.path }}"
+    platform: "{{ trigger.platform }}"


### PR DESCRIPTION
Copies the full run directory of for runs with the platform Miseq i100 and KITM in the RunDescription. Which mens that the action will be called for all Miseq runs, and end early if the RunDescription doesn't match. Not sure if that's an issue or not. 

Will need additions to the config.

